### PR TITLE
notes: Qwen3.5 architecture + vllm-xpu-kernels optimization analysis

### DIFF
--- a/notes/llamacpp_sycl/LLAMACPP_SYCL_DPAS_REPORT.md
+++ b/notes/llamacpp_sycl/LLAMACPP_SYCL_DPAS_REPORT.md
@@ -1,0 +1,227 @@
+# llama.cpp `ggml-sycl`: Lowering to DPAS/SPIR-V — Feasibility & Performance Report
+
+**Source**: `github.com/ggml-org/llama.cpp` @ `master` (fetched into this env), backend
+`ggml/src/ggml-sycl/`.
+**Companion**: `notes/qwen3_5/QWEN3_5_XPU_KERNELS.md` (§8.2/§8.3 — how Intel `sycl-tla` actually
+emits DPAS via inline vISA / `__spirv_SubgroupMatrixMultiplyAccumulateINTEL`). That doc is the
+"how to lower" reference; this doc is the "what to lower and where" analysis for ggml-sycl.
+**Question (from the brief)**: llama.cpp's SYCL backend is not using the XMX (Xe Matrix /
+DPAS) cores; prefill flash-attention does the work in software at large cost. Is it feasible to
+lower the hot paths to DPAS via SPIR-V and apply close-to-hardware techniques, and what would
+have to change in ggml?
+
+**Answer up front**: **Confirmed, and yes.** ggml-sycl uses the matrix engine **nowhere** in
+its own kernels. Every attention matmul and every quantized matmul runs on the vector/EU ALU
+pipe — flash-attention as scalar FMA, quantized GEMM as a **software-emulated** `dp4a`. The
+work is self-contained in the SYCL backend; the changes are additive device kernels plus two
+dispatch hooks, with **no change to ggml core or the GGUF quant formats**. Below is the
+code-verified current state, the specific lowering opportunities, and the change surface.
+
+---
+
+## 1. Current state — verified by reading the kernels
+
+### 1.1 The matrix engine is used nowhere in ggml-sycl's own code
+`grep joint_matrix` over `ggml/src/ggml-sycl/` returns **nothing**. The only matrix-engine
+access in the whole backend is through **oneDNN**, and it is optional and off by default:
+- `DnnlGemmWrapper` (`gemm.hpp:23-89`) wraps `dnnl::matmul` — oneDNN internally targets DPAS.
+- It is gated by `GGML_SYCL_DNNL`, which `CMakeLists.txt:126` sets to **0** unless `DNNL` is
+  found at configure time.
+- It is only used for **non-quantized** matmul: `ggml_sycl_op_mul_mat_sycl` (bf16/f16/f32,
+  `ggml-sycl.cpp:2443-2538`) and `ggml_sycl_mul_mat_batched_sycl` (f16 batched,
+  `:3375-3409`).
+
+So even in the best case (DNNL enabled), **only f16/f32/bf16 dense GEMM** touches XMX. Quantized
+models and all of flash-attention do not.
+
+### 1.2 `SYCL_USE_XMX` is a misnomer inherited from the CUDA port
+`common.hpp:105-109`:
+```c
+// define for XMX in Intel GPU
+// TODO: currently, it's not used for XMX really.
+#if !defined(GGML_SYCL_FORCE_MMQ)
+    #define SYCL_USE_XMX
+#endif
+```
+Where it is referenced (`mmq.cpp:1343` etc., `ggml-sycl.cpp:4205-4207`) it only selects smaller
+MMQ tile dimensions (the `*_AMPERE` config: `MMQ_X=4, MMQ_Y=32`) and caps the MMQ batch to
+`MMQ_MAX_BATCH_SIZE=32` — parameters copied verbatim from the NVIDIA tensor-core path. It emits
+**no matrix instruction**. The `*_AMPERE / *_PASCAL / *_RDNA` naming throughout `mmq.cpp` is all
+carried over from the CUDA/HIP backend.
+
+### 1.3 Quantized matmul = software-emulated `dp4a` (this is the big one)
+The quantized dot products (Q5_0/Q5_1/Q5_K and every other quant) bottom out in `dpct::dp4a`,
+which is **pure scalar C++** — there is not even a hardware DP4A, let alone DPAS
+(`dpct/helper.hpp:1859-1868`):
+```cpp
+inline auto dp4a(T1 a, T2 b, T3 c) {
+  dot_product_acc_t<T1,T2> res = c;
+  auto va = extract_and_sign_or_zero_extend4(a);
+  auto vb = extract_and_sign_or_zero_extend4(b);
+  res += va[0]*vb[0]; res += va[1]*vb[1];
+  res += va[2]*vb[2]; res += va[3]*vb[3];
+  return res;
+}
+```
+Every `vec_dot_q*_q8_1_impl` calls this in an unrolled loop. For **Q5** specifically
+(`vecdotq.hpp:722-801`): the kernel reconstructs the 5-bit value by shuffling the `qh` 5th bit
+into the packed 4-bit `qs` int, then issues `dpct::dp4a(vi, u, sumi)` against the Q8_1
+activations, then scales by the block deltas `d`/`dm`. So a Q5 weight × Q8 activation dot is
+**4 scalar int MACs per dp4a × (unroll)** on the EU pipe.
+
+This is the path for:
+- **MMVQ** (`mmvq.cpp`) — mat×vec for **decode** (batch ≤ `MMVQ_MAX_BATCH_SIZE`).
+- **MMQ** (`mmq.cpp`, `mul_mat_q<...>`) — mat×mat for **prefill** (batch ≤ 32), SLM-tiled but
+  still `vec_dot_*_q8_1_mul_mat` → `dp4a`.
+- **DMMV** (`dmmv.cpp`) — dequantize then f32 vec dot, for some decode cases.
+
+Battlemage's DPAS array can do **int8 8×16×32** matrix-multiply-accumulate natively (the
+`XE_8x16x32_S32S8S8S32_TT` atom / `dpas.s8.s8.8` instruction documented in the sycl-tla report).
+The Q8_1×Q-quant integer GEMM is *exactly* that shape after dequant-to-int8 — and it is being
+done as scalar adds instead.
+
+### 1.4 Flash attention = software FMA, no matrix engine (and an explicit TODO)
+Dispatch (`fattn.cpp:95-223`) has exactly **two** kernels and a comment marking the gap:
+```c
+// Todo: Use the XMX kernel if possible:                       // fattn.cpp:192
+// If there are no tensor cores available, use the generic tile kernel:
+```
+- `BEST_FATTN_KERNEL_VEC` — decode (`Q->ne[1] ≤ 1..2`), `fattn-vec.hpp`.
+- `BEST_FATTN_KERNEL_TILE` — **everything else, including all prefill**, `fattn-tile.hpp`.
+
+There is no XMX/tensor-core kernel; prefill always falls to the software tile kernel. Inside
+`fattn-tile.hpp`:
+- **KQ = K·Qᵀ** (`flash_attn_tile_iter_KQ`, `:325-395`): K/V staged into SLM
+  (`flash_attn_tile_load_tile`), then the dot is a triple-nested loop of
+  `ggml_sycl_mad(KQ_acc, K_k[..], Q_k[..])` — **per-element FMA** in registers (`:380-389`).
+- **online softmax** (`flash_attn_tile_iter`, `:472-573`): `warp_reduce_max`,
+  `sycl::native::exp`, running max/sum rescale — software, scalar.
+- **VKQ = V·P** (`:581-654`): again per-element `VKQ[..].x() += V_k[..].x()*KQ_k[..].x()` FMA.
+
+So both GEMMs inside the prefill attention kernel are scalar FMA on the vector pipe. On a B-series
+GPU this leaves the systolic DPAS array idle during the single most FLOP-heavy phase of prefill —
+precisely the cost the brief describes.
+
+### 1.5 Dispatch map (`ggml_sycl_mul_mat`, `ggml-sycl.cpp:4170-4255`)
+| Case | Path | Hardware |
+|---|---|---|
+| f16, permuted, batch 1 (KQ decode) | `mul_mat_vec_p021` | vector |
+| f16, non-contig, batch 1 (KQV decode) | `mul_mat_vec_nc` | vector |
+| **f16, batch > 1 (KQ/KQV prefill)** | `mul_mat_batched_sycl` → **oneDNN** | **DPAS (if DNNL on)** |
+| quantized, batch 1, dmmv-eligible | `op_mul_mat<dequantize_mul_mat_vec>` | vector |
+| quantized, batch ≤ 32 (decode/small) | `op_mul_mat<mul_mat_vec_q>` (MMVQ) | scalar dp4a |
+| **quantized, prefill** | MMQ (`mul_mat_q`) | **scalar dp4a** |
+| flash attention (all) | tile / vec | **scalar FMA** |
+
+The only DPAS today is the f16-prefill GEMM via oneDNN, *if* it was compiled in. Everything
+quantized and all attention is software.
+
+---
+
+## 2. The lowering opportunity
+
+Three hot paths, in priority order, can be lowered to DPAS. The "how" is in the companion
+sycl-tla report; the salient point is **you do not need `joint_matrix` the C++ API** — the
+portable hardware handle is the SPIR-V cooperative-matrix intrinsic
+`__spirv_SubgroupMatrixMultiplyAccumulateINTEL` (what `joint_matrix` and sycl-tla both lower to),
+and Battlemage exposes DPAS atoms for **bf16/fp16 (16×16×16)** and **int8 (8×16×32)**.
+
+### 2.1 Flash-attention prefill → DPAS (highest impact)
+Replace the `fattn-tile.hpp` scalar QK/PV with a fused-MHA collective:
+- **KQ** (`Q·Kᵀ`) and **PV** (`P·V`) are bf16/fp16 GEMMs → the `f16/bf16` DPAS atom. K/V are
+  already staged as `half2` in SLM (`fattn-tile.hpp:194-312`), so the operands are in the right
+  dtype; what changes is the inner product becomes a `joint_matrix`/SPIR-V MMA over 16×16×16
+  tiles instead of the `ggml_sycl_mad` triple loop.
+- Keep the **online-softmax** epilogue in registers (it is elementwise + warp reductions; it
+  does not need the matrix engine). This is exactly the structure of the sycl-tla FMHA
+  (`chunk_prefill_mainloop.hpp`: two `TiledMMA`s for QK and PV, softmax in registers — companion
+  report §8.1).
+- Wire it into the existing `// Todo: Use the XMX kernel if possible:` slot
+  (`fattn.cpp:192`): add `BEST_FATTN_KERNEL_XMX` ahead of `…_TILE` when the device reports XMX
+  and head dim/dtype are supported.
+- Expected win is largest at **long prefill** (the KQ/PV cost is O(seq²·d) and is the bulk of
+  prefill compute); this is the case the brief calls out.
+
+### 2.2 Quantized GEMM (MMQ/MMVQ) → int8 DPAS
+The Q8_1 activation × quantized weight integer GEMM is the int8-DPAS shape. Two sub-options:
+1. **Dequant-to-int8 + int8 DPAS**: unpack Q5/Q4/Q8 weights to int8 in registers/SLM (the
+   dequant bit-tricks already exist in `dequantize.hpp` / `vecdotq.hpp`), then feed the
+   `XE_8x16x32_S32S8S8S32` DPAS instead of `dp4a`. sycl-tla even has **in-register fused
+   dequant+VNNI** reorder sequences for int4/int8/fp8 (companion report §8.3) that fold the
+   unpack into the load→MMA pipeline.
+2. **Dequant-to-bf16 + bf16 DPAS**: simpler, slightly more bandwidth, reuses the f16 atom; good
+   first step.
+
+Replace `dpct::dp4a` (the scalar emulation, `helper.hpp:1859`) at minimum with the hardware
+path on Xe — but the real win is restructuring `mul_mat_q` to issue block-level DPAS rather than
+per-thread 4-wide dot products.
+
+### 2.3 Dense f16/f32 GEMM — already covered by oneDNN, make it default
+`ggml_sycl_op_mul_mat_sycl` / `…_batched_sycl` already route to oneDNN→DPAS. The gap is that
+`GGML_SYCL_DNNL` defaults **off** (`CMakeLists.txt:126`). For Battlemage, enabling oneDNN (or a
+sycl-tla GEMM) by default closes the dense-GEMM gap with no new kernel.
+
+---
+
+## 3. What would have to change — and where (the ggml surface)
+
+The brief's hypothesis ("changes to ggml") is correct but the scope is narrower than it sounds:
+**all changes are inside `ggml/src/ggml-sycl/`**. The ggml *core* (`ggml.c`, tensor/op
+definitions) and the **GGUF quant block formats are untouched** — the kernels consume the same
+`block_q5_0/1`, `block_q5_K`, `block_q8_1` layouts (`quants.hpp`). Concretely:
+
+1. **New kernels** (additive, no API change):
+   - `fattn-xmx.hpp` — DPAS fused-MHA prefill kernel (model on sycl-tla's `chunk_prefill_*`).
+   - A DPAS path in `mmq.cpp` (e.g. `mul_mat_q_dpas`) for the int8/bf16 MMA, behind a real
+     capability check.
+2. **Dispatch hooks** (two small edits):
+   - `fattn.cpp` — fill the `// Todo: Use the XMX kernel if possible:` branch
+     (`:192`): return `BEST_FATTN_KERNEL_XMX` when `device has XMX && supported(DKQ,DV,dtype)`.
+   - `ggml_sycl_mul_mat` (`ggml-sycl.cpp:4170`) — route quantized prefill to the DPAS MMQ when
+     available, and consider defaulting the f16 batched path to oneDNN/sycl-tla on BMG.
+3. **A real device capability probe**: today `SYCL_USE_XMX` is a compile-time misnomer and
+   `cc`/`VER_GEN12/13` (`common.hpp:100-101`) are placeholder "todo for hardware optimize"
+   constants. Add an actual XMX/architecture query (BMG `intel_gpu_bmg_g21/g31`,
+   `ext_oneapi_architecture`) — `ggml-sycl.cpp:144` already calls
+   `device.ext_oneapi_architecture_is(...)` for the reorder feature, so the mechanism exists.
+4. **Lowering mechanism**: either (a) depend on Intel `sycl-tla` (`cute` `XE_DPAS_TT` atoms +
+   the FMHA/GEMM collectives — most reuse, heaviest dep), or (b) hand-write the SPIR-V
+   `__spirv_SubgroupMatrixMultiplyAccumulateINTEL` MMA with VNNI 2D-block loads (no extra dep,
+   more code). Either targets the same DPAS instruction (companion report §8.2). For a ggml
+   upstream PR, (b) is more palatable (no CUTLASS-scale dependency); for an Arcaine-internal
+   fork, (a) is faster.
+
+**Non-goals / cautions for a port**:
+- The block-q reorder optimization (`should_reorder_tensor`, `reorder_qw_q*`,
+  `ggml-sycl.cpp:3509-3700`) already repacks weights for the SoA MMVQ path — a DPAS MMQ wants a
+  **VNNI**-friendly weight layout, so this is the natural place to add a DPAS-specific reorder
+  rather than inventing a new buffer path.
+- Numerics: the tile kernel scales Q down by 4 to avoid f16 KQ overflow without `v_dot2_f32_f16`
+  (`fattn-tile.hpp:481-485`); a DPAS f16 path with f32 accumulate (the atom's accumulator is
+  f32) removes that hazard — a correctness *improvement*, but validate against the tile kernel.
+- MMQ batch is capped at 32 today (`MMQ_MAX_BATCH_SIZE`); a DPAS MMQ should lift that, since the
+  whole point is throughput at large batch/prefill.
+
+---
+
+## 4. Bottom line
+
+| Path | Today | Hardware used | DPAS-lowerable? |
+|---|---|---|---|
+| FA prefill (tile) | scalar FMA QK/PV + SW softmax | EU/FPU | **Yes — biggest win** (bf16 16×16×16) |
+| FA decode (vec) | scalar FMA | EU/FPU | marginal (vec-bound, low arith intensity) |
+| Quantized prefill (MMQ) | **scalar-emulated `dp4a`** | EU ALU | **Yes** (int8 8×16×32, or bf16) |
+| Quantized decode (MMVQ) | scalar-emulated `dp4a` | EU ALU | partial (bandwidth-bound) |
+| Dense f16/f32 GEMM | oneDNN (if `GGML_SYCL_DNNL`) | **DPAS (optional)** | already; default it on |
+
+The brief's intuition holds: the SYCL backend leaves the matrix engine almost entirely unused,
+prefill flash-attention and quantized GEMM are the two paths paying the largest software tax, and
+both are classic DPAS shapes. The lowering is **feasible within ggml-sycl alone** (no core/format
+changes), the mechanism is the SPIR-V DPAS MMA (with or without sycl-tla), and the highest-value
+first target is a DPAS fused-MHA prefill kernel slotted into the existing `fattn.cpp` TODO.
+
+---
+
+**Document version**: 1.0
+**Reference**: `ggml-org/llama.cpp@master`, `ggml/src/ggml-sycl/{fattn*.hpp,fattn.cpp,mmq.cpp,mmvq.cpp,dmmv.cpp,vecdotq.hpp,dequantize.hpp,gemm.hpp,common.hpp,ggml-sycl.cpp,dpct/helper.hpp}`
+**Companion**: `notes/qwen3_5/QWEN3_5_XPU_KERNELS.md` (DPAS/SPIR-V lowering mechanism)

--- a/notes/qwen3_5/QWEN3_5_ARCHITECTURE.md
+++ b/notes/qwen3_5/QWEN3_5_ARCHITECTURE.md
@@ -1,0 +1,783 @@
+# Qwen3.5 / Qwen3.5-MoE: Implementation Analysis (Dense + MoE, Vision + LM)
+
+**Source**: HuggingFace `transformers==5.12.1` (pulled into this environment via pip)
+**Reference checkpoints**: `Qwen/Qwen3.5-27B` (dense), `Qwen/Qwen3.5-35B-A3B` (MoE)
+**Purpose**: Architecture reference to seed an Arcaine (SYCL + oneDNN) port. This document
+describes *what the reference PyTorch implementation does* and *how the CUDA fast path is
+wired*. It deliberately does **not** prescribe a SYCL design — only the math, data flow,
+shapes, and dependencies another agent needs to implement it correctly.
+
+> Citations use `transformers/models/<model>/<file>.py:<lines>` relative to the installed
+> package (`/usr/local/lib/python3.11/dist-packages/transformers/...`). The `modular_*.py`
+> files are the source of truth; the `modeling_*.py` files are auto-generated and are what
+> actually runs. Both are cited where they diverge.
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Model Family & Inheritance Map](#2-model-family--inheritance-map)
+3. [Configuration System](#3-configuration-system)
+4. [Hybrid Attention Schedule](#4-hybrid-attention-schedule)
+5. [Tensor Shape Reference](#5-tensor-shape-reference)
+6. [Dependencies: the conv1d op library and FLA](#6-dependencies-the-conv1d-op-library-and-fla)
+7. [FORWARD PASS](#7-forward-pass)
+   - 7.1 Top-level multimodal forward
+   - 7.2 Vision encoder
+   - 7.3 M-RoPE / 3D position ids
+   - 7.4 Text decoder loop
+   - 7.5 Gated DeltaNet (linear attention) — the core
+   - 7.6 Full attention layer
+   - 7.7 MLP / Sparse MoE block
+8. [BACKWARD PASS](#8-backward-pass)
+9. [CUDA Optimizations In Place](#9-cuda-optimizations-in-place)
+10. [Weight Manifest](#10-weight-manifest)
+11. [Porting Checklist](#11-porting-checklist)
+
+---
+
+## 1. Executive Summary
+
+"Qwen3.5" (sometimes spoken as 3.5/3.6 — there is no separate `qwen3_6` module; the dense
+and MoE text towers are `qwen3_5` and `qwen3_5_moe`) is a **hybrid linear-attention
+transformer** with an optional **Qwen3-VL vision tower**. The defining feature is that the
+text decoder is **not** a pure softmax-attention stack. Instead each layer is one of two
+token mixers, chosen by a fixed schedule:
+
+- **`linear_attention`** — a **Gated DeltaNet** (gated delta rule, a linear-attention /
+  state-space hybrid) with a short causal **depthwise Conv1d** in front. This is the
+  "conv1d op library" dependency: prefill/decode run through `causal_conv1d` +
+  `flash-linear-attention` (FLA) CUDA kernels, with pure-PyTorch fallbacks.
+- **`full_attention`** — standard GQA softmax attention with QK-norm, partial RoPE, and an
+  output gate.
+
+Default schedule is **3 linear : 1 full** (every 4th layer is full attention). The MoE
+variant swaps every dense MLP for a 256-expert top-8 sparse block with a shared expert.
+
+Both towers reuse the **Qwen3-Next** building blocks (`Qwen3NextGatedDeltaNet`,
+`Qwen3NextAttention`, `Qwen3NextSparseMoeBlock`) and the **Qwen3-VL** multimodal scaffolding
+(vision encoder, interleaved M-RoPE, `masked_scatter` token merge). Qwen3.5 is essentially
+**Qwen3-Next text tower × Qwen3-VL multimodal shell**, minus DeepStack.
+
+Key consequence for a port: there are **two completely different attention codepaths and two
+different cache state types in the same model** (a rolling Conv1d state + a recurrent matrix
+state for linear layers; a standard KV cache for full layers). Getting the hybrid cache and
+the chunked delta-rule recurrence right is the bulk of the work.
+
+---
+
+## 2. Model Family & Inheritance Map
+
+```
+Qwen3-Next (text-only hybrid)                Qwen3-VL (softmax VLM)
+  Qwen3NextGatedDeltaNet  ───────┐            Qwen3VLVisionModel
+  Qwen3NextAttention             │            Qwen3VLModel (merge + M-RoPE)
+  Qwen3NextSparseMoeBlock        │            Qwen3VLForConditionalGeneration
+  Qwen3NextModel (decoder loop)  │              │
+        │                        │             │
+        ▼                        ▼             ▼
+   ┌──────────────── Qwen3.5 (dense) ──────────────┐
+   │ Qwen3_5GatedDeltaNet  (slims in_proj, see 7.5)│
+   │ Qwen3_5Attention = Qwen3NextAttention         │
+   │ Qwen3_5DecoderLayer (linear|full + dense MLP) │
+   │ Qwen3_5TextModel    (hybrid decoder loop)     │
+   │ Qwen3_5VisionModel  (Qwen3-VL minus DeepStack)│
+   │ Qwen3_5Model / ...ForConditionalGeneration    │
+   └───────────────────────────────────────────────┘
+                         │
+                         ▼
+   ┌──────────────── Qwen3.5-MoE ──────────────────┐
+   │ Qwen3_5MoeGatedDeltaNet = Qwen3_5GatedDeltaNet│
+   │ Qwen3_5MoeSparseMoeBlock (256 exp, top-8 + sh)│
+   │ Qwen3_5MoeDecoderLayer (linear|full + MoE MLP)│
+   │ everything else mirrors the dense tower       │
+   └───────────────────────────────────────────────┘
+```
+
+Source anchors:
+- Dense modular: `transformers/models/qwen3_5/modular_qwen3_5.py` (imports at lines 38–57).
+- MoE modular: `transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py` (imports 24–50).
+- Next building blocks: `transformers/models/qwen3_next/modeling_qwen3_next.py`.
+- VL scaffolding: `transformers/models/qwen3_vl/modeling_qwen3_vl.py`.
+
+The dense decoder layer hard-codes a dense `Qwen3_5MLP`
+(`modular_qwen3_5.py:351-404`); the MoE layer hard-codes a `Qwen3_5MoeSparseMoeBlock` for
+**every** layer (`modular_qwen3_5_moe.py:187-198`) — note `mlp_only_layers` and
+`decoder_sparse_step` are deleted from the MoE config, so there is no "every-N-layers MoE"
+gating like Qwen3-Next has; **all** layers are sparse.
+
+---
+
+## 3. Configuration System
+
+Top-level config is a 2-way composite (no audio): `{vision_config, text_config}`
+(`configuration_qwen3_5.py:143-189`). Special token ids are shared across dense/MoE:
+`image_token_id=248056`, `video_token_id=248057`, `vision_start_token_id=248053`,
+`vision_end_token_id=248054`.
+
+### 3.1 Dense text config — `Qwen3_5TextConfig`
+(`configuration_qwen3_5.py:27-113`)
+
+| Field | Default | Notes |
+|---|---|---|
+| `vocab_size` | 248320 | larger than Qwen3-Next's 151936 |
+| `hidden_size` | 4096 | |
+| `intermediate_size` | 12288 | dense MLP |
+| `num_hidden_layers` | 32 | |
+| `num_attention_heads` | 16 | full-attn Q heads |
+| `num_key_value_heads` | 4 | full-attn KV heads (GQA, 4× group) |
+| `head_dim` | 256 | **explicit**, not hidden/heads |
+| `linear_conv_kernel_dim` | 4 | depthwise causal conv kernel |
+| `linear_key_head_dim` | 128 | DeltaNet K/Q head dim |
+| `linear_value_head_dim` | 128 | DeltaNet V head dim |
+| `linear_num_key_heads` | 16 | DeltaNet K/Q heads |
+| `linear_num_value_heads` | 32 | DeltaNet V heads (2× key heads) |
+| `partial_rotary_factor` | 0.25 | set in `__post_init__`, BC default |
+| `rms_norm_eps` | 1e-6 | |
+| `layer_types` | auto | see §4 |
+| `max_position_embeddings` | 32768 | |
+
+`__post_init__` (`configuration_qwen3_5.py:104-113`) builds `layer_types` from
+`full_attention_interval` (default **4**):
+```python
+layer_types = ["linear_attention" if (i+1) % 4 else "full_attention"
+               for i in range(num_hidden_layers)]
+```
+The MoE config does the identical thing (`configuration_qwen3_5_moe.py:112-121`).
+
+In the **modular** form the dense text config subclasses `Qwen3NextConfig` and *deletes* the
+MoE attributes via `AttributeError()` sentinels (`modular_qwen3_5.py:114-126`):
+`num_experts`, `num_experts_per_tok`, `moe_intermediate_size`,
+`shared_expert_intermediate_size`, `decoder_sparse_step`, `norm_topk_prob`,
+`mlp_only_layers`, `output_router_logits`, `router_aux_loss_coef`. The dense tower has **no
+router and no aux loss**.
+
+### 3.2 MoE text config — `Qwen3_5MoeTextConfig`
+(`configuration_qwen3_5_moe.py:27-121`)
+
+Diffs vs dense:
+
+| Field | Default |
+|---|---|
+| `hidden_size` | 2048 (smaller) |
+| `num_hidden_layers` | 40 |
+| `num_key_value_heads` | 2 |
+| `num_experts` | 256 |
+| `num_experts_per_tok` | 8 |
+| `moe_intermediate_size` | 512 |
+| `shared_expert_intermediate_size` | 512 |
+| `output_router_logits` | False |
+| `router_aux_loss_coef` | 0.001 |
+
+The linear-attention block dims (`linear_*`), `head_dim=256`, and `vocab_size=248320` are
+identical to the dense tower. `intermediate_size`, `decoder_sparse_step`, `norm_topk_prob`,
+`mlp_only_layers` are deleted in the modular (`modular_qwen3_5_moe.py:109-116`) — every
+layer is a sparse block and the router normalizes unconditionally (see §7.7).
+
+### 3.3 Vision config — `Qwen3_5VisionConfig`
+(`configuration_qwen3_5.py:116-140`, modular `modular_qwen3_5.py:129-139`)
+
+Subclass of `Qwen3VLVisionConfig` that **deletes `deepstack_visual_indexes`** — Qwen3.5 drops
+DeepStack feature injection entirely.
+
+| Field | Default | Notes |
+|---|---|---|
+| `depth` | 27 | ViT blocks |
+| `hidden_size` | 1152 | vision width |
+| `intermediate_size` | 4304 | vision MLP |
+| `num_heads` | 16 | head_dim = 1152/16 = 72 |
+| `in_channels` | 3 | |
+| `patch_size` | 16 | |
+| `temporal_patch_size` | 2 | video temporal patch |
+| `spatial_merge_size` | 2 | 2×2 patch merge → ×4 width at merger |
+| `out_hidden_size` | 3584 | projected to LM space |
+| `num_position_embeddings` | 2304 | learned pos table; `num_grid_per_side = sqrt(2304)=48` |
+| `hidden_act` | `gelu_pytorch_tanh` | |
+
+> ⚠️ Dimension mismatch to watch: vision `out_hidden_size=3584` but dense LM `hidden_size=4096`
+> (MoE LM `hidden_size=2048`). The default sub-configs are not internally consistent as a
+> *runnable* pair; real checkpoints ship matched configs. Always read `out_hidden_size` and
+> the text `hidden_size` from the actual checkpoint `config.json`, do not assume.
+
+---
+
+## 4. Hybrid Attention Schedule
+
+`layer_types[i]` ∈ {`"linear_attention"`, `"full_attention"`}. With the default
+`full_attention_interval=4` and 32 dense layers:
+
+```
+idx :  0  1  2  3 | 4  5  6  7 | 8  9 10 11 | ...
+type:  L  L  L  F | L  L  L  F | L  L  L  F | ...   (F at idx 3,7,11,15,19,23,27,31)
+```
+3 linear mixers then 1 full-attention mixer, repeating. MoE (40 layers) → full at
+3,7,…,39. Per layer the decoder picks the mixer in `__init__`
+(dense `modular_qwen3_5.py:351-362`, MoE `modular_qwen3_5_moe.py:187-198`):
+
+```python
+if layer_type == "linear_attention":
+    self.linear_attn = Qwen3_5GatedDeltaNet(config, layer_idx)
+elif layer_type == "full_attention":
+    self.self_attn = Qwen3_5Attention(config, layer_idx)
+self.mlp = <dense Qwen3_5MLP | Qwen3_5MoeSparseMoeBlock>
+self.input_layernorm        = Qwen3_5RMSNorm(...)
+self.post_attention_layernorm = Qwen3_5RMSNorm(...)
+```
+
+The decoder loop builds **two masks** and dispatches per layer
+(`Qwen3_5TextModel.forward`, `modular_qwen3_5.py:531-554`):
+```python
+causal_mask      = create_causal_mask(...)                      # for full_attention
+linear_attn_mask = self._update_linear_attn_mask(attention_mask, past_key_values)
+...
+layer_mask = linear_attn_mask if layer_types[i]=="linear_attention" else causal_mask
+```
+`_update_linear_attn_mask` (inherited `modeling_qwen3_next.py:990-1002`) returns `None`
+(i.e. "attend to everything, no zeroing") when decoding with cached state or when the 2D mask
+is all-ones; otherwise it forwards the 2D padding mask so DeltaNet can zero padded tokens.
+**Left padding** is assumed for linear-attention batches.
+
+Both mixer types share **one** rotary embedding (`Qwen3_5TextRotaryEmbedding`,
+`modular_qwen3_5.py:171-192`) computed once per forward; only full-attention layers consume
+`position_embeddings`. RoPE here is **partial** (`partial_rotary_factor=0.25` → only the
+first `0.25*256 = 64` dims of each head are rotated; see `apply_rotary_pos_emb`
+`modeling_qwen3_next.py:180-215`, which splits `q_rot|q_pass`).
+
+RoPE is also **M-RoPE** (multimodal 3D: temporal/height/width) with interleaved sections
+`[11,11,10]` (`Qwen3_5TextRotaryEmbedding.__init__`, `modular_qwen3_5.py:174`). The text
+position-id path expands to 4 rows `[text, t, h, w]` and splits text vs. multimodal
+(`Qwen3_5TextModel.forward`, `modular_qwen3_5.py:517-529`). See §7.3.
+
+---
+
+## 5. Tensor Shape Reference
+
+Notation: `B`=batch, `S`=sequence length, `H`=hidden. Dense defaults shown; sub in MoE
+numbers where noted. Derived linear-attention dims:
+- `key_dim   = linear_key_head_dim   * linear_num_key_heads   = 128 * 16 = 2048`
+- `value_dim = linear_value_head_dim * linear_num_value_heads = 128 * 32 = 4096`
+- `conv_dim  = key_dim*2 + value_dim   = 2048*2 + 4096 = 8192`
+- full-attn QKV: Q proj emits `num_heads * head_dim * 2 = 16*256*2 = 8192` (Q **and** an
+  output gate, split in half), K/V each `num_kv_heads * head_dim = 4*256 = 1024`.
+
+| Tensor | Shape | Where |
+|---|---|---|
+| `input_ids` | `(B, S)` | |
+| `inputs_embeds` | `(B, S, 4096)` | embed_tokens |
+| **Linear attn** | | `Qwen3_5GatedDeltaNet.forward` |
+| `mixed_qkv` (pre-conv) | `(B, conv_dim, S)` = `(B, 8192, S)` | transposed for Conv1d |
+| `conv1d` weight | `(conv_dim, 1, kernel=4)` depthwise (`groups=conv_dim`) | |
+| `query`,`key` (post split/reshape) | `(B, S, 16, 128)` → repeat→ `(B,S,32,128)` | `num_v/num_k=2` |
+| `value` | `(B, S, 32, 128)` | |
+| `g` (decay), `beta` | `(B, S, 32)` | per value head |
+| `recurrent_state` (cache) | `(B, num_v_heads=32, head_k=128, head_v=128)` | matrix state |
+| `conv_state` (cache) | `(B, conv_dim=8192, kernel-1=3)` | rolling conv window |
+| DeltaNet output | `(B, S, 4096)` | `out_proj: value_dim→H` |
+| **Full attn** | | `Qwen3NextAttention.forward` |
+| `query_states`,`gate` | each `(B, 16, S, 256)` | Q proj chunked in 2 |
+| `key/value_states` | `(B, 4, S, 256)` | GQA |
+| KV cache (per full layer) | `(B, 4, S_kv, 256)` ×2 | standard |
+| **MoE** | | |
+| `router_logits` | `(B*S, 256)` | |
+| `routing_weights` / `selected_experts` | `(B*S, 8)` | top-8 |
+| `experts.gate_up_proj` | `(256, 2*512, 2048)` | 3D packed |
+| `experts.down_proj` | `(256, 2048, 512)` | |
+| **Vision** | | |
+| `pixel_values` | `(num_patches, in_ch*t_patch*p*p)` = `(N, 3*2*16*16=1536)` | flattened patches |
+| patch_embed (Conv3d) out | `(N, 1152)` | |
+| post-merger `image_embeds` | `(N/4, 3584)` | spatial_merge 2×2 → /4 |
+| `image_grid_thw` | `(num_images, 3)` | (t,h,w) in patch units |
+| `cu_seqlens` | `(num_windows+1,)` int32 | packed attn boundaries |
+
+---
+
+## 6. Dependencies: the conv1d op library and FLA
+
+The linear-attention fast path depends on **two external CUDA libraries**, both optional with
+PyTorch fallbacks (`modeling_qwen3_next.py:47-62`):
+
+1. **`causal_conv1d`** (Dao-AILab/causal-conv1d) — provides
+   - `causal_conv1d_fn(x, weight, bias, activation, seq_idx)` — fused depthwise causal
+     conv + activation over a full sequence (prefill / chunked decode).
+   - `causal_conv1d_update(x, conv_state, weight, bias, activation)` — single-step decode;
+     updates the rolling `conv_state` in place.
+   This is the "conv1d op library" referenced in the task. It replaces `nn.Conv1d` with a
+   kernel that (a) fuses the SiLU activation, (b) avoids materializing the `kernel-1`
+   left-pad, and (c) does the in-place ring-buffer state update for decode.
+
+2. **`flash-linear-attention` (FLA, `fla` package)** — provides
+   - `chunk_gated_delta_rule(...)` — chunked parallel scan of the gated delta rule
+     (prefill / multi-token).
+   - `fused_recurrent_gated_delta_rule(...)` — sequential recurrence for single-token decode.
+   - `FusedRMSNormGated` — fused RMSNorm + SiLU gate used as the DeltaNet output norm.
+
+Resolution logic (`modeling_qwen3_next.py:344-346, 553-563`):
+```python
+is_fast_path_available = all((causal_conv1d_fn, causal_conv1d_update,
+                              chunk_gated_delta_rule, fused_recurrent_gated_delta_rule))
+self.causal_conv1d_fn       = causal_conv1d_fn                       # or None → nn.Conv1d path
+self.causal_conv1d_update   = causal_conv1d_update or torch_causal_conv1d_update
+self.chunk_gated_delta_rule = chunk_gated_delta_rule or torch_chunk_gated_delta_rule
+self.recurrent_gated_delta_rule = fused_recurrent_gated_delta_rule or torch_recurrent_gated_delta_rule
+```
+**For an Arcaine port the pure-PyTorch fallbacks are the executable spec**:
+`torch_causal_conv1d_update` (`:349-364`), `torch_chunk_gated_delta_rule` (`:373-451`),
+`torch_recurrent_gated_delta_rule` (`:454-495`). They are numerically equivalent to the CUDA
+kernels and fully readable — port from these, validate against the kernels.
+
+Full-attention layers additionally route through `ALL_ATTENTION_FUNCTIONS` (flash-attn / SDPA
+/ eager) via `config._attn_implementation` (`modeling_qwen3_next.py:310-323`).
+
+---
+
+## 7. FORWARD PASS
+
+### 7.1 Top-level multimodal forward — `Qwen3_5Model.forward`
+(`modular_qwen3_5.py:591-664`)
+
+```
+input_ids ──embed_tokens──► inputs_embeds (B,S,H)
+   │
+   ├─ if pixel_values:       image_embeds = visual(pixel_values, image_grid_thw).pooler_output
+   │     image_mask = (input_ids == image_token_id)
+   │     inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)   # :628
+   ├─ if pixel_values_videos: same path via get_video_features                    # :630-639
+   │
+   ├─ position_ids = compute_3d_position_ids(...)   # M-RoPE, see 7.3             # :641-650
+   └─ language_model(inputs_embeds, position_ids, attention_mask, past_key_values)
+```
+Multimodal tokens are spliced into the text stream by **`masked_scatter`** on the embedding
+tensor (inherited from `Qwen3VLModel`, `modeling_qwen3_vl.py:628`). The vision encoder runs
+once; its merged tokens replace `image_token_id`/`video_token_id` placeholders. There is **no
+cross-attention** — vision is fully tokenized into the LM sequence. (Unlike Qwen3-VL, Qwen3.5
+drops DeepStack, so there is no per-layer visual feature injection.)
+
+`Qwen3_5ForConditionalGeneration` (`modular_qwen3_5.py:680-685`) is the generation entry; it
+inherits `Qwen3VLForConditionalGeneration` and only re-exposes `get_image_features` /
+`get_video_features`. The LM head + loss live there.
+
+### 7.2 Vision encoder — `Qwen3_5VisionModel.forward`
+(`modular_qwen3_5.py:429-484`)
+
+`Qwen3_5VisionModel` is `Qwen3VLVisionModel` with DeepStack deleted in `__init__`
+(`modular_qwen3_5.py:433-436`: `del self.deepstack_visual_indexes`,
+`del self.deepstack_merger_list`). Pipeline:
+
+```
+pixel_values (N, 1536)                                  # N flattened (t·h·w) patches
+   │  Qwen3VLVisionPatchEmbed: Conv3d(3→1152, k=stride=[2,16,16])   modeling_qwen3_vl.py:80-97
+   ▼
+hidden_states (N, 1152)
+   + pos_embeds   # bilinear-interpolated learned table, get_vision_bilinear_indices_and_weights
+   │              # pos_embed: Embedding(2304, 1152), 48×48 grid, bilinear to (h,w)  :692-703
+   ▼
+rotary_pos_emb = rotary_pos_emb(get_vision_position_ids(grid_thw, merge=2))  # (N, head_dim/2)
+emb = cat([rope, rope]); position_embeddings = (emb.cos(), emb.sin())        # :463-469
+   │
+   ├─ for blk in blocks (depth=27):   # Qwen3VLVisionBlock                    modeling_qwen3_vl.py:271-299
+   │     h = h + attn(norm1(h), cu_seqlens, position_embeddings)             # packed varlen attn
+   │     h = h + mlp(norm2(h))                                                # GELU-tanh MLP
+   ▼
+merged = merger(h)   # Qwen3VLVisionPatchMerger: norm → fc1 → GELU → fc2     modeling_qwen3_vl.py:114-127
+   ▼
+return BaseModelOutputWithPooling(last_hidden_state=h, pooler_output=merged) # :481-484
+```
+
+Vision attention (`Qwen3VLVisionAttention`, `modeling_qwen3_vl.py:188-268`) is **non-causal**
+(`is_causal=False`) and **packed variable-length**: under flash-attn it passes `cu_seqlens`
+directly (one segment per image/frame, `:225-242`); otherwise it `torch.split`s by segment and
+runs SDPA/eager per segment (`:243-264`). `cu_seqlens` come from
+`get_vision_cu_seqlens` (`vision_utils.py:35-50`): cumulative `h*w` repeated `t` times.
+
+Patch merger (`modeling_qwen3_vl.py:114-127`) concatenates `spatial_merge_size² = 4` adjacent
+patches → width `1152*4 = 4608`, LayerNorm, `fc1(4608→4608)`, GELU, `fc2(4608→3584)`. So the
+LM receives `N/4` tokens at `out_hidden_size=3584`.
+
+Vision RoPE position ids: `get_vision_position_ids` (`vision_utils.py:53-83`) produces
+`(total_tokens, 2)` (row,col), reshaped through the `merge_size` blocking so the merge groups
+are contiguous. The learned absolute pos-embed is bilinearly interpolated from the fixed
+48×48 grid to the actual `(h,w)` via `get_vision_bilinear_indices_and_weights`
+(`vision_utils.py:147-217`), returning 4 corner indices + weights `(4, total_thw)`.
+
+### 7.3 M-RoPE / 3D position ids
+(`Qwen3VLModel.get_rope_index`, `modeling_qwen3_vl.py:933-1024`;
+`compute_3d_position_ids`, `:1111-1158`)
+
+Text tokens get identical `(t,h,w)` indices (all three equal the running text position);
+image/video tokens get a 3D grid where `t` advances per frame and `h,w` index the merged patch
+grid (`get_vision_position_ids` member, `:875-931`). `mm_token_type_ids` (0=text, 1=image,
+2=video) drives the grouping (`itertools.groupby`, `:993-1016`). Videos use timestamp tokens
+between frames, so `video_grid_thw` is repeat-expanded per frame with `t` set to 1
+(`:968-970`). The rotary module then **interleaves** the three sections via
+`apply_interleaved_mrope` (`modeling_qwen3_vl.py:375-390`): layout goes from chunked
+`[TTT…HHH…WWW]` to interleaved `[THWTHW…TT]` using `mrope_section` (`[11,11,10]` for 3.5).
+
+`rope_deltas` is cached on the model so incremental decode reuses the offset
+(`:1131-1154`).
+
+### 7.4 Text decoder loop — `Qwen3_5TextModel.forward`
+(`modular_qwen3_5.py:491-561`)
+
+```python
+inputs_embeds = embed_tokens(input_ids)                          # if not provided
+past_key_values = DynamicCache(config) if use_cache else None    # hybrid cache, see §8
+# position_ids → 4 rows [text,t,h,w]; split text_position_ids (row0) from M-RoPE rows 1:
+causal_mask      = create_causal_mask(..., position_ids=text_position_ids)
+linear_attn_mask = self._update_linear_attn_mask(attention_mask, past_key_values)
+position_embeddings = self.rotary_emb(hidden_states, position_ids)   # M-RoPE cos/sin
+for i, layer in enumerate(layers):
+    layer_mask = linear_attn_mask if layer_types[i]=="linear_attention" else causal_mask
+    hidden_states = layer(hidden_states, position_embeddings, attention_mask=layer_mask,
+                          position_ids=text_position_ids, past_key_values=past_key_values, ...)
+hidden_states = self.norm(hidden_states)     # final Qwen3_5RMSNorm
+```
+
+Each `Qwen3_5DecoderLayer.forward` (`modular_qwen3_5.py:364-404`) is a standard
+pre-norm residual pair:
+```
+residual = h;  h = input_layernorm(h)
+h = linear_attn(h, ...) | self_attn(h, ...)[0]    # token mixer
+h = residual + h
+residual = h;  h = post_attention_layernorm(h)
+h = mlp(h)                                          # dense MLP or MoE block
+h = residual + h
+```
+
+**RMSNorm note** (`Qwen3NextRMSNorm`, `modeling_qwen3_next.py:152-169`): weight is stored
+**zero-centered** — `output * (1.0 + weight)` — and initialized to zeros
+(`_init_weights`, `modular_qwen3_5.py:415-426`). Norm is computed in fp32 then cast back. A
+port must add 1.0 to the loaded weight (or fold it in).
+
+### 7.5 Gated DeltaNet (linear attention) — the core
+`Qwen3_5GatedDeltaNet` (`modular_qwen3_5.py:195-334`), built on
+`Qwen3NextGatedDeltaNet` (`modeling_qwen3_next.py:498-716`).
+
+**Qwen3.5's specialization** (`modular_qwen3_5.py:195-210`): it *replaces* Qwen3-Next's two
+fused input projections (`in_proj_qkvz`, `in_proj_ba` + the `fix_query_key_value_ordering`
+de-interleave) with **four separate, already-ordered** projections:
+```python
+self.in_proj_qkv = nn.Linear(H, key_dim*2 + value_dim, bias=False)   # Q|K|V fused, contiguous
+self.in_proj_z   = nn.Linear(H, value_dim, bias=False)               # output-gate input
+self.in_proj_b   = nn.Linear(H, num_v_heads, bias=False)             # β (delta gate)
+self.in_proj_a   = nn.Linear(H, num_v_heads, bias=False)             # α (decay) input
+# fix_query_key_value_ordering raises — not needed (weights pre-ordered)   :209-210
+```
+This is a **weight-layout simplification only**; the math is identical to Qwen3-Next. A port
+should target the Qwen3.5 layout (4 clean projections), not the Next interleaved one.
+
+Forward (`modular_qwen3_5.py:212-334`), three regimes keyed on cache state + `seq_len`:
+
+**(a) Common front-end** (all regimes):
+```python
+hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)  # zero pads
+mixed_qkv = in_proj_qkv(h).transpose(1,2)        # (B, conv_dim=8192, S)
+z = in_proj_z(h).reshape(B, S, -1, head_v_dim=128)
+b = in_proj_b(h);  a = in_proj_a(h)              # (B, S, num_v_heads=32)
+```
+
+**(b) Causal depthwise Conv1d** (the conv1d op):
+- *Single-token cached decode* (`use_precomputed_states and seq_len==1`, `:244-252`):
+  `causal_conv1d_update(mixed_qkv, conv_state, conv1d.weight.squeeze(1), conv1d.bias, act)`
+  — reads + writes the rolling `conv_state` ring buffer in place.
+- *Prefill / chunked decode* (`:253-274`):
+  - if cached, prepend `conv_state` so the conv sees correct left context (`:259`);
+  - write next state: `conv_state = pad(mixed_qkv, (kernel-1 - len, 0))` (`:261-262`);
+  - run `causal_conv1d_fn(x, weight, bias, activation, seq_idx)` (`:263-270`), or fallback
+    `F.silu(conv1d(mixed_qkv)[..., :S])` (`:272`);
+  - if cached, trim back to last `seq_len` (`:273-274`).
+- The Conv1d is **depthwise** (`groups=conv_dim`, kernel=4, left-pad=kernel-1), applied to the
+  concatenated Q|K|V channels **before** splitting into heads.
+
+**(c) Split + gating params** (`:276-296`):
+```python
+mixed_qkv = mixed_qkv.transpose(1,2)
+query, key, value = split(mixed_qkv, [key_dim, key_dim, value_dim], dim=-1)
+query = query.reshape(B,S,-1,head_k=128); key likewise; value→(B,S,-1,head_v=128)
+beta = b.sigmoid()                                        # (B,S,32)
+g = -A_log.float().exp() * softplus(a.float() + dt_bias)  # log-decay (B,S,32), fp32
+if num_v_heads // num_k_heads > 1:                        # 32/16 = 2
+    query = query.repeat_interleave(2, dim=2); key likewise   # GQA-style head expand
+```
+`A_log` and `dt_bias` are per-(value-)head learnable params (init `A_log~log(U(0,16))`,
+`dt_bias=ones`; `_init_weights` `modular_qwen3_5.py:416-420`). `g` is the **log** decay; the
+kernels exponentiate internally.
+
+**(d) Delta-rule scan**:
+- *decode, seq_len==1* → `recurrent_gated_delta_rule(q,k,v, g, beta, initial_state=recurrent_state,
+  output_final_state=True, use_qk_l2norm_in_kernel=True)` (`:298-308`).
+- *prefill / chunked* → `chunk_gated_delta_rule(q,k,v, g, beta,
+  initial_state=recurrent_state_or_None, output_final_state=cache?, use_qk_l2norm_in_kernel=True,
+  cu_seqlens=cu_seq_lens_q)` (`:309-321`).
+
+The recurrence (from the readable fallback `torch_recurrent_gated_delta_rule`,
+`modeling_qwen3_next.py:454-495`), per timestep `t`, per head:
+```
+S_t = S_{t-1} * exp(g_t)                       # gated decay of the (head_k × head_v) state
+kv  = (S_t * k_t).sum over key-dim            # read
+Δ   = (v_t - kv) * β_t                          # delta correction
+S_t = S_t + outer(k_t, Δ)                       # write
+out_t = (S_t * q_t).sum over key-dim
+```
+with `q,k` L2-normalized first (`use_qk_l2norm_in_kernel=True` → `l2norm`,
+`modeling_qwen3_next.py:367-370`) and `q` scaled by `1/sqrt(head_k_dim)`. The chunked variant
+(`:373-451`) reformulates this as: intra-chunk lower-triangular correction solved by a
+`chunk_size=64` forward substitution (`:418-421`), plus inter-chunk state carry — algebraically
+equal, parallelized over chunks. **This chunk/recurrence equivalence is the single most
+important thing to get right and to unit-test.**
+
+**(e) State write + output norm** (`:323-333`):
+```python
+if cache: cache.update_recurrent_state(last_recurrent_state, layer_idx)
+core_attn_out = norm(core_attn_out.reshape(-1, head_v), z.reshape(-1, head_v))  # RMSNormGated
+output = out_proj(core_attn_out.reshape(B, S, -1))     # value_dim → H
+```
+`Qwen3NextRMSNormGated` (`modeling_qwen3_next.py:67-82`) is RMSNorm **then** multiply by
+`SiLU(z)` — the output gate `z` comes from `in_proj_z`, *not* from the attention. On CUDA this
+is FLA's `FusedRMSNormGated`.
+
+### 7.6 Full attention layer — `Qwen3NextAttention.forward`
+(`modeling_qwen3_next.py:255-329`)
+
+GQA softmax attention with three Qwen-isms:
+1. **Q projection is double-width and split into Q + output-gate** (`:267-298`):
+   `q_proj: H → num_heads*head_dim*2`, chunked into `query_states` and `gate`; the final
+   `attn_output = attn_output * sigmoid(gate)` (`:326`) before `o_proj`.
+2. **QK-norm on the head dim** (`:279-301`): `Qwen3NextRMSNorm(head_dim)` applied to Q and K
+   per head before RoPE.
+3. **Partial RoPE** (`partial_rotary_factor=0.25`): only first 64 of 256 head dims rotated
+   (`apply_rotary_pos_emb`, `:180-215`).
+KV cache update is the standard `past_key_values.update(k, v, layer_idx)` (`:307-308`). Scaling
+`head_dim**-0.5`. Attention backend chosen via `ALL_ATTENTION_FUNCTIONS`.
+
+> `Qwen3_5Attention` is a bare subclass (`modular_qwen3_5.py:337-338`) — identical to
+> Qwen3-Next.
+
+### 7.7 MLP / Sparse MoE block
+
+**Dense MLP** (`Qwen3NextMLP`, `modeling_qwen3_next.py:719-732`): standard SwiGLU
+`down(silu(gate(x)) * up(x))`, `intermediate_size=12288`.
+
+**MoE block** `Qwen3_5MoeSparseMoeBlock` (generated `modeling_qwen3_5_moe.py:795-814`):
+```python
+shared = shared_expert(x)                                   # dense SwiGLU, inter=512
+logits, weights, idx = gate(x)                              # router, top-8
+expert_out = experts(x, idx, weights)                       # routed experts
+shared = sigmoid(shared_expert_gate(x)) * shared            # gated shared expert
+out = expert_out + shared
+```
+- **Router** `Qwen3_5MoeTopKRouter` (`modeling_qwen3_5_moe.py:776-792`):
+  `softmax(F.linear(x, weight))` over 256 experts in fp32 → `topk(8)` →
+  **always** renormalize `top_value /= top_value.sum()` (no `norm_topk_prob` flag, unlike
+  Qwen3-Next's router which gates on the config). Returns `(logits, scores, indices)`.
+- **Experts** `Qwen3_5MoeExperts` = `Qwen3NextExperts` (`modeling_qwen3_next.py:735-772`):
+  weights are **3D packed** tensors `gate_up_proj (256, 1024, 2048)` and
+  `down_proj (256, 2048, 512)`. Forward builds a one-hot `expert_mask`, finds hit experts, and
+  loops **only over experts that received tokens** (`:760-770`), gathering tokens, running
+  `silu(gate)*up → down`, scaling by routing weight, and `index_add_`-scattering back. This is
+  the reference (gather/scatter) path; the `@use_experts_implementation` decorator
+  (`:735`) lets a fused/grouped-GEMM kernel replace it.
+- **Shared expert** is a normal dense SwiGLU (`inter=512`) gated by a scalar
+  `sigmoid(shared_expert_gate(x))` and **added** to the routed output.
+
+The dense decoder layer's MLP returns a tensor directly; the Next-style layer also handles a
+tuple return (`modeling_qwen3_next.py:878-881`) for router-logits capture. Qwen3.5-MoE
+captures router logits via `_can_record_outputs` for the optional load-balancing aux loss
+(`load_balancing_loss_func`, `modeling_qwen3_next.py:1005-1084`).
+
+---
+
+## 8. BACKWARD PASS
+
+There is **no hand-written backward** anywhere in these models — training relies on autograd
+plus the custom-op backward formulas registered by the kernel libraries. What a port must
+reproduce is (a) which ops are differentiable, (b) where fp32 is forced, (c) the custom-op
+gradients, and (d) what state is *not* in the autograd graph.
+
+### 8.1 What carries gradients
+
+- **All `nn.Linear` projections** (text, vision, experts incl. 3D-packed parameters), the
+  **Conv1d weight/bias**, embeddings, the `lm_head`, all `RMSNorm`/`LayerNorm` weights, and
+  the DeltaNet scalars **`A_log`** and **`dt_bias`** — standard autograd.
+- The decay `g = -exp(A_log) * softplus(a + dt_bias)` (`modular_qwen3_5.py:293`) is computed
+  in **fp32** specifically so the gradient to `A_log` doesn't underflow/`-inf` in fp16 — the
+  inline comment flags this. A port's backward must keep this term in fp32.
+
+### 8.2 Custom-op backward (the kernels)
+
+- **`causal_conv1d_fn`** has a fused CUDA backward (grad wrt `x`, `weight`, `bias`). The
+  PyTorch fallback `F.silu(conv1d(...))` is plain autograd and is the reference for gradients.
+  Note the **decode** path uses `causal_conv1d_update`, which mutates `conv_state` **in place**;
+  that in-place state update is a cache side effect, **not** part of the training graph
+  (training runs the full-sequence `causal_conv1d_fn`, not the update kernel).
+- **`chunk_gated_delta_rule`** (FLA) carries the backward for the gated delta-rule scan
+  (grads wrt `q,k,v,g,beta` and the initial state). During training `output_final_state=False`
+  unless cache is requested, and `initial_state=None` (`:309-321` passes
+  `recurrent_state if use_precomputed_states else None`) — i.e. a *training* prefill starts
+  from a zero state and does **not** thread a state gradient across calls. The chunked
+  algorithm’s intra-chunk forward-substitution loop (`torch_chunk_gated_delta_rule:418-444`)
+  is differentiable as written; the CUDA kernel implements the same Jacobian analytically.
+- **`fused_recurrent_gated_delta_rule`** is the **decode** path (`seq_len==1`,
+  `use_precomputed_states`) — used only under `@torch.no_grad()` generation, so its backward
+  is effectively never exercised in training.
+- **`FusedRMSNormGated`** backward covers the RMSNorm + SiLU-gate fusion; the fallback
+  `Qwen3NextRMSNormGated` (`:67-82`) computes the same in fp32 and is the gradient reference.
+- **Full-attention** backward is whatever the selected backend provides (flash-attn’s fused
+  backward, or SDPA/eager autograd). The Q/gate split and `sigmoid(gate)` multiply
+  (`:295-326`) are ordinary autograd.
+
+### 8.3 MoE backward
+
+The reference experts loop (`modeling_qwen3_next.py:748-772`) is autograd-friendly: the
+`one_hot`/`expert_hit` selection runs under `torch.no_grad()` (`:755-758`) — only an index
+computation, no gradient — while the per-expert `linear → silu*up → linear`, the
+`* top_k_weights` scaling, and the `index_add_` scatter are all differentiable, so gradients
+flow to the routed expert weights, the **router** (through `routing_weights`), the shared
+expert, and `shared_expert_gate`. The **top-k selection itself is non-differentiable**
+(straight-through via the selected probabilities only). The optional
+**load-balancing aux loss** (`:1005-1084`, scaled by `router_aux_loss_coef=0.001`) adds a
+gradient path to the router logits when `output_router_logits=True`.
+
+A grouped-GEMM kernel replacing the loop (via `@use_experts_implementation`) must supply its
+own backward producing identical grads to this gather/scatter reference.
+
+### 8.4 Gradient checkpointing & state
+
+Every decoder layer is a `GradientCheckpointingLayer` (`modular_qwen3_5.py:351`,
+`modular_qwen3_5_moe.py:189`) and the vision blocks/merger likewise, so activations are
+recomputed in backward by default when checkpointing is on. The **caches** (`conv_states`,
+`recurrent_states`, KV) are inference-only state objects (`DynamicCache`,
+`cache_utils.py:862-959`) and are **outside** the autograd graph — training does not populate
+or backprop through them. `_is_stateful=True` / `_skip_keys_device_placement=["past_key_values"]`
+mark them as non-parameter state.
+
+---
+
+## 9. CUDA Optimizations In Place
+
+These are the GPU-specific fast paths an Arcaine implementation will be measured against
+(architecture only — no SYCL prescription):
+
+1. **Fused causal depthwise Conv1d** (`causal_conv1d_fn` / `_update`): fuses left-pad + grouped
+   conv + SiLU; the decode kernel does an in-place ring-buffer `conv_state` update of shape
+   `(B, 8192, 3)`, avoiding re-convolving history. Falls back to `nn.Conv1d` + slice.
+2. **Chunked gated delta rule** (`chunk_gated_delta_rule`): block-parallel scan (`chunk_size=64`)
+   that turns an inherently sequential recurrence into matmul-heavy chunk-local work + a small
+   inter-chunk carry — this is what makes linear-attention prefill GPU-efficient. The
+   `cu_seqlens` arg lets it handle **packed variable-length** sequences without padding.
+3. **Fused recurrent gated delta rule** (`fused_recurrent_gated_delta_rule`): single-kernel
+   per-step state update for decode (`seq_len==1`), reading/writing the `(B,32,128,128)`
+   recurrent matrix state.
+4. **`FusedRMSNormGated`**: one kernel for RMSNorm + SiLU gate (DeltaNet output).
+5. **Flash-Attention varlen for vision**: packed `cu_seqlens` attention over all
+   images/frames in one call (`modeling_qwen3_vl.py:225-242`); non-flash backends fall back to
+   per-segment SDPA.
+6. **Flash-Attention / SDPA for full-attention text layers** via `ALL_ATTENTION_FUNCTIONS`
+   dispatch, with QK-norm and partial RoPE applied before the kernel.
+7. **3D-packed expert weights + hit-only expert loop**: experts stored as
+   `(num_experts, …)` tensors so a grouped/fused GEMM can replace the Python loop
+   (`@use_experts_implementation`, `modeling_qwen3_next.py:735`); the reference skips experts
+   that received zero tokens.
+8. **Hub kernel hooks** on the VL text path: `@use_kernel_forward_from_hub("RMSNorm")`,
+   `@use_kernel_func_from_hub("rotary_pos_emb")`, `@use_kernelized_func` (`modeling_qwen3_vl.py:
+   393, 414, 440`) allow swapping in optimized RMSNorm/RoPE kernels at load time.
+9. **fp32 islands**: RMSNorm, the decay `g`, router softmax, and RoPE freq computation are
+   forced to fp32 (`maybe_autocast(enabled=False)`, `.float()` casts) regardless of model
+   dtype — correctness-critical, not optional.
+10. **Static cache addresses** for compile: conv/recurrent states call
+    `torch._dynamo.mark_static_address` (`cache_utils.py:933, 940`) and the model sets
+    `_can_compile_fullgraph` on the VL base — the hybrid cache is `torch.compile`-friendly.
+
+---
+
+## 10. Weight Manifest
+
+Per-layer names (dense; `linear_attention` layers have `linear_attn.*`, `full_attention`
+layers have `self_attn.*`):
+
+```
+model.embed_tokens.weight                         (248320, 4096)
+# --- linear_attention layer i ---
+model.layers.{i}.linear_attn.in_proj_qkv.weight   (key_dim*2+value_dim=8192, 4096)
+model.layers.{i}.linear_attn.in_proj_z.weight     (value_dim=4096, 4096)
+model.layers.{i}.linear_attn.in_proj_b.weight     (num_v_heads=32, 4096)
+model.layers.{i}.linear_attn.in_proj_a.weight     (32, 4096)
+model.layers.{i}.linear_attn.conv1d.weight        (conv_dim=8192, 1, 4)     # depthwise, no bias by default
+model.layers.{i}.linear_attn.A_log                (32,)
+model.layers.{i}.linear_attn.dt_bias              (32,)
+model.layers.{i}.linear_attn.norm.weight          (head_v_dim=128,)         # RMSNormGated
+model.layers.{i}.linear_attn.out_proj.weight      (4096, value_dim=4096)
+# --- full_attention layer j ---
+model.layers.{j}.self_attn.q_proj.weight          (num_heads*head_dim*2=8192, 4096)
+model.layers.{j}.self_attn.k_proj.weight          (num_kv*head_dim=1024, 4096)
+model.layers.{j}.self_attn.v_proj.weight          (1024, 4096)
+model.layers.{j}.self_attn.o_proj.weight          (4096, 4096)
+model.layers.{j}.self_attn.q_norm.weight          (head_dim=256,)
+model.layers.{j}.self_attn.k_norm.weight          (256,)
+# --- MLP (dense) ---
+model.layers.{i}.mlp.{gate,up}_proj.weight        (12288, 4096)
+model.layers.{i}.mlp.down_proj.weight             (4096, 12288)
+# --- MLP (MoE, all layers) ---
+model.layers.{i}.mlp.gate.weight                  (num_experts=256, hidden=2048)
+model.layers.{i}.mlp.experts.gate_up_proj         (256, 2*512, 2048)
+model.layers.{i}.mlp.experts.down_proj            (256, 2048, 512)
+model.layers.{i}.mlp.shared_expert.{gate,up}_proj.weight (512, 2048)
+model.layers.{i}.mlp.shared_expert.down_proj.weight      (2048, 512)
+model.layers.{i}.mlp.shared_expert_gate.weight    (1, 2048)
+# --- norms / head ---
+model.layers.{i}.input_layernorm.weight           (H,)   # zero-centered, use (1+w)
+model.layers.{i}.post_attention_layernorm.weight  (H,)
+model.norm.weight                                  (H,)
+lm_head.weight                                     (vocab, H)   # not tied (tie_word_embeddings=False)
+# --- vision (prefix model.visual.) ---
+visual.patch_embed.proj.{weight,bias}             Conv3d(3→1152, k=[2,16,16])
+visual.pos_embed.weight                           (2304, 1152)
+visual.blocks.{k}.norm1/norm2.{weight,bias}       LayerNorm(1152)
+visual.blocks.{k}.attn.qkv.{weight,bias}          (3*1152, 1152)
+visual.blocks.{k}.attn.proj.{weight,bias}         (1152, 1152)
+visual.blocks.{k}.mlp.linear_fc1.{weight,bias}    (4304, 1152)
+visual.blocks.{k}.mlp.linear_fc2.{weight,bias}    (1152, 4304)
+visual.merger.norm.{weight,bias}                  LayerNorm(1152)  # pre-merge norm dim
+visual.merger.linear_fc1.{weight,bias}            (4608, 4608)
+visual.merger.linear_fc2.{weight,bias}            (3584, 4608)
+```
+Checkpoints may contain `mtp.*` (multi-token-prediction head) keys — ignored on load
+(`_keys_to_ignore_on_load_unexpected`, `modular_qwen3_5.py:669`).
+
+---
+
+## 11. Porting Checklist
+
+1. **Config**: parse nested `{vision_config, text_config}`; derive `layer_types` from
+   `full_attention_interval` (default 4) if absent. Read `head_dim`, all `linear_*` dims,
+   `partial_rotary_factor`, and `mrope_section` explicitly. Read vision `out_hidden_size` and
+   text `hidden_size` from the actual checkpoint (do not assume the default sub-configs match).
+2. **RMSNorm**: zero-centered weights → multiply by `(1 + w)`; compute in fp32.
+3. **Linear attention** (the hard part): implement the **Qwen3.5** 4-projection layout
+   (`in_proj_qkv/z/b/a`); depthwise causal Conv1d (kernel 4, left-pad 3) over the 8192 conv
+   channels; `beta=sigmoid(b)`, `g=-exp(A_log)*softplus(a+dt_bias)` in fp32;
+   L2-norm q,k; scale q by `1/sqrt(128)`; run the gated delta rule. Port the **chunked**
+   algorithm from `torch_chunk_gated_delta_rule` and unit-test it against
+   `torch_recurrent_gated_delta_rule` for equivalence. Output = `RMSNormGated(out, z)` then
+   `out_proj`.
+4. **Hybrid cache**: per-layer `conv_states (B,8192,3)` + `recurrent_states (B,32,128,128)` for
+   linear layers; standard KV `(B,4,S,256)×2` for full layers. Decode: `seq_len==1` →
+   conv-update + recurrent rule; chunked decode → prepend conv state, trim output.
+5. **Full attention**: Q proj double-width → split Q/gate; QK-norm per head; partial RoPE
+   (first 64 dims); `attn * sigmoid(gate)` before `o_proj`; GQA repeat 4×.
+6. **MoE**: fp32 softmax router over 256 experts → top-8 → renormalize; 3D-packed experts
+   gather/scatter (or grouped GEMM); shared expert gated by `sigmoid(shared_expert_gate)`,
+   added.
+7. **Vision**: Conv3d patch embed; bilinear-interpolated learned pos-embed (48×48 grid);
+   2D vision RoPE; 27 non-causal varlen blocks (`cu_seqlens` per image/frame); 2×2 patch
+   merger → 3584; **no DeepStack**.
+8. **Merge**: `masked_scatter` vision tokens into `image_token_id`/`video_token_id` slots;
+   build M-RoPE 3D position ids via `get_rope_index` + interleave with `mrope_section=[11,11,10]`.
+9. **Validate** layer-by-layer against the HF reference (fallback kernels) on a tiny config
+   before wiring the fused kernels.
+
+---
+
+**Document version**: 1.0
+**Author**: architecture analysis for Arcaine SYCL port
+**Reference**: `transformers==5.12.1`, `models/{qwen3_5, qwen3_5_moe, qwen3_next, qwen3_vl, qwen3_vl_moe}`

--- a/notes/qwen3_5/QWEN3_5_ONEDNN_SYCLTLA_INTEGRATION.md
+++ b/notes/qwen3_5/QWEN3_5_ONEDNN_SYCLTLA_INTEGRATION.md
@@ -1,0 +1,209 @@
+# Qwen3.5 Dense on Arcaine: oneDNN + SYCL-TLA Integration Plan
+
+**Audience**: Arcaine kernel devs building the Qwen3.5 **dense** path (SYCL + oneDNN, Battlemage
+`bmg_g21/g31`).
+**Companions**: `QWEN3_5_ARCHITECTURE.md` (the PyTorch reference + component list),
+`QWEN3_5_XPU_KERNELS.md` (how the Intel-GPU kernels and DPAS lowering actually work).
+**Thesis**: oneDNN owns every standard dense GEMM; **SYCL-TLA** (`intel/sycl-tla`, the Intel
+CUTLASS-for-SYCL) provides the matrix-engine primitives for the two kernels oneDNN cannot
+express as a single primitive — the **fused flash-attention** and the **Gated-DeltaNet linear
+attention**. Both run on one `sycl::queue` over shared USM and lower to the same DPAS
+instruction, so they compose with no copies.
+
+---
+
+## 1. Why a hybrid (not one or the other)
+
+- **oneDNN** is a primitive library: `matmul`, `convolution`, `softmax`, `layer_normalization`,
+  `eltwise`, `binary`, `reorder`, `reduction`, plus a Graph API. Its `matmul` is the right tool
+  for `[M,K]·[K,N]` with DPAS, post-op fusion, scales/zero-points, and an internal primitive
+  cache. It has **no single primitive** for: the gated delta-rule recurrence, a causal Conv1d
+  with rolling state, RMSNorm-gated, interleaved partial M-RoPE, or a *fused* flash-attention
+  with online softmax (its Graph-API SDPA is coarse and does not touch the GDN side at all).
+- **SYCL-TLA** is not a primitive library — it is a set of `cute` device building blocks (DPAS
+  MMA atoms, 2D block copies, in-register reorder/dequant, split barriers) plus collective
+  templates. It is what you use to *write* the bespoke kernels, with direct DPAS control.
+
+So: oneDNN for the boring GEMMs (most of the FLOPs, least of the effort), SYCL-TLA atoms for the
+two custom kernels that carry Qwen3.5's novelty.
+
+### Interop mechanism (the part that makes it free)
+Both bind to the same SYCL context/queue and operate on the same USM allocations:
+```cpp
+// oneDNN side (see llama.cpp ggml-sycl/gemm.hpp:43-44 for the working pattern)
+dnnl::engine eng = dnnl::sycl_interop::make_engine(sycl_device, sycl_context);
+dnnl::stream  s  = dnnl::sycl_interop::make_stream(eng, queue);   // same queue as TLA kernels
+dnnl::memory  m(md, eng, usm_ptr);                                // wraps the SAME pointer
+```
+SYCL-TLA kernels are plain `queue.submit(...)` over the same USM pointers. Ordering is the
+queue's; no host sync, no device copies at the oneDNN↔TLA seam — only a possible **layout
+reorder** (see §5).
+
+---
+
+## 2. oneDNN's territory — the dense GEMMs
+
+Use `dnnl::matmul` (batched/3D where applicable) for every projection and MLP. oneDNN handles
+the DPAS, the bf16/fp16/fp8/NVFP4 dtypes (Arcaine already uses NVFP4 matmul), per-channel /
+per-group scales + zero-points for quantized weights, and post-op fusion.
+
+| Qwen3.5 dense GEMM | oneDNN call | Fusion (post-ops) |
+|---|---|---|
+| `q_proj` (double-width → Q + output-gate) | `matmul` | split halves after; gate applied later |
+| `k_proj`, `v_proj`, `o_proj` | `matmul` | bias if present |
+| GDN `in_proj_qkv`, `in_proj_z/b/a`, `out_proj` | `matmul` | — |
+| MLP `gate_proj` | `matmul` | **`eltwise swish` (SiLU) post-op** |
+| MLP `up_proj` | `matmul` | — |
+| MLP `down_proj` | `matmul` | preceded by `binary mul` (gate⊙up) |
+| `lm_head` | `matmul` | **`eltwise tanh` post-op** for final-logit softcap (scaled) |
+| Vision: patch-embed (Conv3d→GEMM), QKV, MLP fc1/fc2, merger fc1/fc2 | `matmul` (+`conv` for patch embed) | GELU-tanh post-op on MLP/merger |
+
+**SwiGLU concretely**: `tmp = matmul(x, Wgate)` with `swish` post-op; `up = matmul(x, Wup)`;
+`act = binary_mul(tmp, up)`; `y = matmul(act, Wdown)`. (Or a single custom SwiGLU kernel if you
+want to fuse the two input GEMMs — but the oneDNN path is the no-effort default.)
+
+**Quantized projections** (if running W4A16/W8A16/NVFP4 weights): keep them in oneDNN with
+weight scales/zero-points; you do **not** need SYCL-TLA's mixed-input mainloop unless you want
+in-kernel dequant fused into a *custom* GEMM. oneDNN already exposes the quantized matmul Arcaine
+uses for DiffusionGemma.
+
+oneDNN standalone primitives also cover the easy non-GEMM ops if you don't fuse them:
+`softmax`, `eltwise` (SiLU/GELU/tanh), `binary`, `reorder`, `reduction`. RMSNorm specifically is
+**not** a clean oneDNN primitive (its `layer_normalization` computes mean+variance, not the
+mean-square-only RMSNorm) — treat RMSNorm as custom (§4).
+
+---
+
+## 3. SYCL-TLA's territory — the bespoke kernels
+
+Two kernels oneDNN cannot host as one primitive. Build them from these SYCL-TLA primitives
+(reference implementations live in vllm-xpu-kernels `csrc/xpu/{attn,gdn_attn}`):
+
+### 3.1 Fused flash-attention (full-attention layers)
+- **Primitives**: `MMA_Atom<XE_DPAS_TT<8,float,bf16/fp16>>` ×2 (one tiling for `Q·Kᵀ`, one for
+  `P·V`); `XE_LOAD_2D`/`_VNNI` + `make_block_2d_copy_*` for Q/K/V tiles; `XE_PREFETCH_2D` for
+  L1 prefetch; `barrier_arrive`/`barrier_wait` for the pipeline; `Xe_Reorder` if the KV-cache is
+  quantized (in-register dequant before the MMA).
+- **Template to lift**: the FMHA collective (`cutlass/.../collective/chunk_prefill_mainloop.hpp`)
+  — two `TiledMMA`s with the **online softmax kept in registers** ("P in registers" `XeDefault`
+  policy), varlen via `cu_seqlens`.
+- **Stays outside the kernel** (caller's job): QK-norm + partial M-RoPE (custom, §4); the
+  `attn_output * sigmoid(gate)` output gate (elementwise, §4).
+
+### 3.2 Gated-DeltaNet linear attention (the novel layers)
+- **Causal Conv1d (+ rolling state, + L2-norm)**: SLM-staged tile with an explicit `Width-1`
+  halo = the conv state; fuse the q/k **L2-norm** into the conv epilogue. Use `XE_LOAD_2D` /
+  SLM `local_accessor`; no DPAS here (it's depthwise). oneDNN `convolution` is a *fallback* for
+  the bare conv but cannot fuse the state update or the l2norm.
+- **Chunked gated delta rule**: the 5-kernel DPAS pipeline (prepare → compute_A → inverse →
+  compute_wu → fwd_o) using `XE_DPAS_TT` 64×64×32 tiles, the `gemm_TTS`/`gemm_STS`/
+  `gemm_TTS_fused_2A`/`gemm_TTS_k_multi` helpers, `Xe_Reorder` for fragment→VNNI, split barriers,
+  and SLM for the `g/β/A` scratch. **No oneDNN equivalent exists.** Keep the BMG-DPAS vs
+  PVC-native-SLM split for the triangular inverse.
+- **Decay + gating math** (`g = -exp(A_log)·softplus(a+dt_bias)`, `β = sigmoid(b)`) and the
+  **RMSNorm-gated** output: custom elementwise, fp32 (§4).
+
+### The SYCL-TLA primitive inventory (reusable in any custom kernel)
+| Primitive | Header | Use |
+|---|---|---|
+| `XE_DPAS_TT` MMA atom + `TiledMMA`/`TiledMMAHelper` | `cute/arch/mma_xe.hpp`, `atom/mma_traits_xe.hpp` | the matrix multiply in FA & GDN |
+| 2D block copy: `XE_LOAD_2D`/`_VNNI`/`_TRANSPOSE`, `XE_STORE_2D`, `XE_PREFETCH_2D` + `make_block_2d_copy_*` | `cute/arch/copy_xe_2d.hpp`, `atom/copy_traits_xe_2d.hpp` | register-resident operand loads, VNNI, L1 prefetch |
+| `Xe_Reorder` (fused convert + VNNI; int4/fp8/e2m1/ue8m0 dequant) | `cute/arch/reorder_xe.hpp` | KV/weight dequant inside a kernel |
+| Split barriers `barrier_arrive`/`barrier_wait` | `cute/util/xe_split_barrier.hpp` | workgroup software pipeline |
+| Collective mainloops (dense / mixed-input / FMHA) | `cutlass/gemm/collective/xe_mma*.hpp`, FMHA collective | lift wholesale as kernel skeletons |
+| `cute` layout algebra + tile schedulers (data-parallel / stream-K / persistent) | `cute/*`, `cutlass/gemm/kernel/xe_*scheduler*` | tiling the custom kernels |
+
+---
+
+## 4. The leftover custom kernels (neither oneDNN nor TLA matmul)
+
+Small SYCL kernels (subgroup reductions, elementwise); no matrix engine. SYCL-TLA's subgroup
+helpers are optional conveniences here.
+- **RMSNorm** and **RMSNorm-gated** (`out = rms(x)·(1+w)`, gated variant `·SiLU(z)`), fp32
+  reduction. Note the weight is stored zero-centered → multiply by `(1+w)`.
+- **QK-norm + partial/interleaved M-RoPE** (one subgroup per (token,head); fuse the two head-dim
+  passes — see vllm-xpu `fused_qknorm_rope.cpp`, SIMD32). `mrope_section = [11,11,10]`.
+- **Output gate** `attn_out *= sigmoid(gate)` and the GDN decay/β math (fp32).
+- **embed_tokens** gather; **token/placeholder scatter** for multimodal (not in pure-dense).
+
+---
+
+## 5. The oneDNN ⇄ SYCL-TLA seam — layouts & hand-off
+
+The only correctness/perf concern at the boundary is **operand layout**, because DPAS wants
+VNNI-packed B and the two libraries pick their own internal layouts.
+
+- **oneDNN → custom TLA kernel** (e.g. projections feed the FA/GDN kernel): oneDNN writes
+  row/col-major USM; the TLA kernel's `make_block_2d_copy_*` + `Xe_Reorder` handle VNNI packing
+  *on load*, so usually **no explicit reorder** is needed — just make sure the oneDNN output
+  obeys the 2D-block alignment (base 64 B, row pitch %4 B; see `QWEN3_5_XPU_KERNELS.md` §8.3).
+- **custom TLA kernel → oneDNN** (e.g. attention output feeds `o_proj`): emit a plain
+  row-major tile (`XE_STORE_2D`), which oneDNN matmul consumes directly.
+- **When a reorder is unavoidable** (a packed/VNNI weight needs a different layout than oneDNN
+  expects), use **oneDNN's `reorder` primitive** (stays in the oneDNN graph, cached) rather than
+  a bespoke kernel.
+- **dtype at the seam**: keep activations in bf16/fp16 through the chain; oneDNN matmul with f32
+  accumulate and the DPAS atom's f32 accumulator agree numerically. Avoid silent f16 KQ overflow
+  by accumulating attention in f32 (the DPAS atom already does).
+- **Alignment is a hard gate**: oneDNN `matmul` (`MainloopXeL1Staged::can_implement`) and the 2D
+  block messages both require 128-bit copy alignment / 64 B base; size your KV-cache and weight
+  buffers accordingly or the fast paths silently won't apply.
+
+---
+
+## 6. Build / dependency notes
+
+- **oneDNN**: already in Arcaine's stack (source build, SYCL CPU+GPU runtime). Enable the
+  primitive cache; set `fpmath_mode::f16`/`bf16` for the matmuls.
+- **SYCL-TLA**: header-only `cute`/CUTLASS-SYCL, BSD-3-Clause (vendoring is fine, check per-file
+  headers). It is a heavy CUTLASS-scale template dependency; pull at a pinned revision (vllm-xpu
+  pins `cd763790…`) and target `intel_gpu_bmg_g21`. You only need the `cute` device headers
+  (`include/cute`, `include/cutlass/gemm/collective`, `…/kernel`), not the host build.
+- Compile both with the same oneAPI/`icpx`; SYCL-TLA's DPAS path needs
+  `-fsycl-targets=intel_gpu_bmg_g21` and the large-GRF property (`grf_size<256>`).
+
+---
+
+## 7. Bring-up order (recommended)
+
+1. **All projections + MLP + lm_head on oneDNN** (with SwiGLU/softcap post-ops). This stands up
+   the whole dense graph minus the two attention families.
+2. **Full-attention via a SYCL-TLA FMHA kernel** (lift the vllm-xpu `attn/xe_2` collective);
+   wire QK-norm+RoPE+output-gate as the custom pre/post kernels. Validate vs the HF reference.
+3. **GDN linear attention** (lift vllm-xpu `gdn_attn`): conv1d+l2norm kernel, then the chunked
+   delta-rule pipeline. This is the highest-effort piece; unit-test the chunk↔recurrence
+   equivalence at `chunk_size=64`.
+4. **RMSNorm / gating** custom kernels throughout.
+5. Only then consider replacing any oneDNN GEMM with a custom TLA GEMM (e.g. to fuse dequant for
+   quantized weights via `xe_mma_mixed_input.hpp`) — measure first; oneDNN is usually already at
+   DPAS peak for plain GEMM.
+
+---
+
+## 8. Summary table
+
+| Qwen3.5 dense component | Implement with | Primitive(s) |
+|---|---|---|
+| All projections, MLP, lm_head, vision GEMMs | **oneDNN** | `matmul` + post-ops (swish/tanh/binary), scales |
+| SwiGLU | **oneDNN** | matmul swish post-op + binary-mul |
+| Quantized weight GEMMs (W4A16/NVFP4/FP8) | **oneDNN** | `matmul` + scales/zero-points |
+| RMSNorm / RMSNorm-gated | custom | subgroup-reduce SYCL kernel (fp32) |
+| QK-norm + partial M-RoPE, output gate | custom | subgroup SYCL kernel |
+| Full attention (QK·softmax·PV) | **SYCL-TLA** | `XE_DPAS_TT`×2 + 2D-copy + reorder + barriers + online softmax |
+| GDN causal Conv1d (+state,+l2norm) | custom + SYCL-TLA | 2D-copy/SLM halo; fuse l2norm |
+| GDN chunked gated delta rule | **SYCL-TLA** | `XE_DPAS_TT` 5-kernel pipeline (no oneDNN equiv) |
+| Layout hand-off / weight repack | **oneDNN** `reorder` or `Xe_Reorder` | only where VNNI/layout mismatch |
+
+**Bottom line**: oneDNN gets ~all the dense FLOPs (projections/MLP/lm_head/vision) for almost no
+effort and at DPAS peak; SYCL-TLA's `XE_DPAS_TT` + 2D-copy + reorder + barrier atoms are exactly
+what you need to hand-write the **flash-attention** and **Gated-DeltaNet** kernels that oneDNN
+cannot express — and because both share the queue/USM/DPAS, they compose into one Qwen3.5 dense
+forward pass without copies.
+
+---
+
+**Document version**: 1.0
+**Reference**: `intel/sycl-tla@cd763790`, `vllm-project/vllm-xpu-kernels@main`
+(`csrc/xpu/{attn,gdn_attn}` reference kernels), oneDNN matmul interop pattern from
+`ggml-org/llama.cpp` `ggml/src/ggml-sycl/gemm.hpp`.
+**Companions**: `QWEN3_5_ARCHITECTURE.md`, `QWEN3_5_XPU_KERNELS.md`

--- a/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
+++ b/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
@@ -547,6 +547,112 @@ Caveats:
 
 ---
 
-**Document version**: 1.0
-**Reference**: `vllm-project/vllm-xpu-kernels@main`, `csrc/xpu/{gdn_attn,attn,grouped_gemm,onednn,sycl}`, `csrc/moe`, `csrc/fused_qknorm_rope.cpp`
+## 10. Xe2 hardware facts → kernel-writing techniques (dense + MoE)
+
+This section distills the *hardware facts* that drive the kernel designs above, read out of
+`sycl-tla` and the vllm-xpu kernels, and maps each to the Qwen3.5 dense and MoE codepaths.
+These are the numbers/constraints to design around when writing Xe2 (Battlemage `bmg_g21/g31`)
+kernels.
+
+### 10.1 The hardware-fact table
+
+| Fact | Value / rule | Source | Consequence |
+|---|---|---|---|
+| **Subgroup = 16 for DPAS** | `SubgroupSize = 16` | `dispatch_policy.hpp:1306`, `mma_traits_xe.hpp:81` | one subgroup issues one DPAS; MMA N is fixed at 16 |
+| **Subgroup = 32 for memory/elementwise** | `reqd_sub_group_size(32)` | `fused_silu_mul_mxfp4_quant.cpp:42`, `fused_qknorm_rope.cpp:24` | wider SIMD for load/store/reduce-bound kernels; pick per kernel, not globally |
+| **Large GRF mode** | `intel::grf_size<256>` | `…interface.hpp:121`, GDN `:1286` | matrix kernels run register-resident; request 256-reg GRF |
+| **Workgroup = up to 32 subgroups** | `Num_SGs = ATOM_M*ATOM_N*ATOM_K`, `MaxSG=32` | `xe_mma.hpp:99`, `xe_mma_builder.inl:95` | size WG to a full Xe-core's subgroup budget |
+| **DPAS systolic depth = 8** | `dpas.<TB>.<TA>.8.<M>` | `mma_xe.hpp:98` | K-substeps per issue = 8 |
+| **DPAS K per atom** | `K = 256/max(bitsA,bitsB)` → 16 bf16/fp16, 32 int8, 64 int4, 8 tf32 | `mma_xe.hpp:50` | bigger K-step for lower precision = more work/issue |
+| **B operand must be VNNI** | pack factor `BV = 32/bits(B)` | `mma_traits_xe.hpp:70,89` | weights need VNNI layout (or VNNI 2D-load / reorder) |
+| **2D block load: dims ≤ 2²⁴, base %64 B, width/pitch %4 B, x %4** | asserts | `copy_traits_xe_2d.hpp:120-127,175` | tensor base/stride alignment is a *hard* requirement |
+| **2D block: height ≤ 32 load / ≤ 8 store, ≤ 4 blocks, width ≤ 64 B** | static_asserts | `copy_xe_2d.hpp:58-61` | caps the per-message tile |
+| **Cache line = 64 B (512 bit)** | prefetch width = `gcd(shape, 512/bits)` | `copy_traits_xe_2d.hpp:1562` | prefetch in whole cache lines |
+| **Copy alignment = 128-bit; batch stride = 512-bit** | `can_implement` | `xe_mma.hpp:145-146` | min element alignment for the 2D copy path |
+| **GEMM mainloop uses NO SLM** | `SmemLayoutAtom = void` | `xe_mma_builder.inl:115`, `xe_mma.hpp` | operands gmem→GRF; SLM only for reductions/scratch |
+| **Pipeline depth = Stages (2–3)** | `MainloopXeL1Staged<Stages>`, prefetch `Stages` ahead | `dispatch_policy.hpp:1304`, `xe_mma.hpp:255-270` | software-pipelined L1 prefetch, not SLM double-buffer |
+| **Split barriers** | `barrier_arrive(2)` / `barrier_wait(2)` (scope 2 = workgroup) | `xe_mma.hpp:262,277`, `xe_split_barrier.hpp` | arrive early, do work, wait late — hides latency |
+| **PVC ≠ BMG** | `is_bmg()` selects DPAS triangular inverse; PVC uses native SLM (sycl-tla accuracy bug) | `chunk_gated_delta_rule_kernels_xe2.hpp:1348-1411` | keep an arch-gated fallback |
+
+### 10.2 Dense Qwen3.5 path — techniques
+
+The dense tower is full-attention layers + linear-attention (GDN) layers + dense SwiGLU MLP.
+
+- **Dense MLP / projection GEMM** → `MainloopXeL1Staged` (`xe_mma.hpp`). The reference pattern:
+  register-resident A/B via 2D block loads, **prefetch `Stages` k-tiles ahead into L1**,
+  `copy → reorder(→VNNI) → cute::gemm(DPAS) ` inside split barriers, fp32 accumulator. No SLM.
+  This is the template for any plain `[M,K]·[K,N]` on Xe2.
+- **Full attention (FMHA)** → two DPAS tilings (`TiledMMAQK`, `TiledMMAPV`) with the softmax
+  epilogue kept in registers (§8.1) — "P in registers" `XeDefault` policy; varlen via
+  `cu_seqlens`. QK-norm + partial RoPE stay *outside* the FMHA (fused in
+  `fused_qknorm_rope.cpp`, SIMD32, one subgroup per (token,head)).
+- **GDN linear attention** (the novel part):
+  - *Causal Conv1d*: SLM-staged with an explicit `Width-1` halo = the rolling conv state
+    (`chunk_causal_conv1d_tiled_xe2.hpp`); 256 features/WG (`wg_size 64 × elems 4`); **fuses
+    L2-norm into the conv epilogue** when `2·head_k_dim ≤ 256` — eliminates a full-tensor pass.
+  - *Chunked gated delta rule*: a **5-kernel pipeline** (prepare → compute_A → inverse →
+    compute_wu → fwd_o) where the matmuls are 64×64×32 DPAS tiles with the four tuned
+    `SGLayout` policies (2×2 / 2×1 / 4×2 / 1×1); the triangular inverse is a blocked 4×4 of
+    16×16 DPAS on BMG, native-SLM on PVC; `g = -exp(A_log)·softplus(a+dt_bias)` in fp32.
+  - *Register-sharing fusions*: `gemm_TTS_fused_2A` shares one B fragment across two DPAS issues
+    (W×S and Q×S from one state load); `gemm_TTS_k_multi` folds a per-K decay scale into the A
+    fragment before the MAD.
+
+### 10.3 MoE Qwen3.5 path — techniques
+
+The MoE tower replaces every MLP with 256-expert top-8 routing + a shared expert. The
+load-imbalance and quantization are the Xe2-specific challenges.
+
+- **Persistent work-stealing tile scheduler** (the key MoE technique, `grouped_gemm_xe2.hpp:106-217`):
+  ragged rows-per-expert means static tile→WG assignment starves some WGs. Instead a global
+  `atomic_buffer` counter hands out the *next* tile across all experts; each WG, after finishing
+  a tile, does `cutlass::atomicAdd(atomic_buffer,1)`, broadcasts the new id through SLM
+  (`slm_mem[0]`), and recomputes its `(expert, m, n)` coord. This keeps all subgroups busy
+  across the uneven expert sizes. The dispatch policy is `KernelXePtrArrayCooperative`
+  (`MainloopXeL1StagedGroup`).
+- **Tile policy by average tokens-per-expert**: `A_avg_M = total_M/num_experts` selects
+  M-skinny tiles (`w*a16_policy_m_{8,16,32}`) for MoE decode vs square tiles for prefill
+  (`grouped_gemm_xe2_interface.hpp:287-368`). Per-expert batches are tiny, so the M tile must be
+  too or the array runs under-filled.
+- **Dedicated mixed-precision mainloops** for the int4/MXFP4 experts:
+  `MainloopIntelXeXMX16(Group)MixedPrecision`, `…W8A8`, `…GroupFP8`, `…FP8Scaling`
+  (`dispatch_policy.hpp:1263-1287`) — there is a purpose-built collective for each Qwen3.5-MoE
+  quant scheme.
+- **Fused in-register dequant** for the expert weights: the `reorder()` step converts int4 / e2m1
+  (MXFP4) / ue8m0 (MXFP4 scale) / fp8 → bf16/half *and* VNNI-packs in one vISA sequence (§8.3),
+  so the 4-bit expert weight is upconverted on the path from 2D-load to DPAS — no separate
+  dequant kernel.
+- **Fused SwiGLU + MXFP4 quant** for the expert activations (`fused_silu_mul_mxfp4_quant.cpp`):
+  one pass computes `silu(gate)·up`, the per-group (32-wide) absmax via **butterfly subgroup
+  reduction** (`permute_group_by_xor`, no SLM), the **ue8m0 power-of-two scale**
+  `exp2(ceil(log2(absmax/FP4_MAX)))`, and packs two e2m1 nibbles/byte — SIMD32, 16-byte
+  vectorized loads. This is the down-proj input prep, fused to avoid a round trip.
+- **On-device routing/scatter** (`csrc/moe/`): softmax/sigmoid top-k scoring with subgroup
+  reductions (`topk.cpp`), `fused_moe_prologue` (permute + scale gather into a workspace),
+  `moe_align_sum` (pad per-expert counts to tile size), `moe_gather`/`remap_hidden_states` —
+  the whole route→GEMM→unroute stays on the GPU, driven by index tensors, no host sync.
+
+### 10.4 Rules of thumb (distilled)
+
+1. **Pick subgroup size per kernel**: 16 if it issues DPAS, 32 if it's load/store/reduce-bound.
+2. **Keep GEMM operands in registers** (large GRF + 2D block loads); reserve SLM for reductions,
+   conv halos, and cross-subgroup scratch — not for staging GEMM operands.
+3. **Prefetch whole cache lines `Stages` tiles ahead** and wrap `copy→reorder→gemm` in split
+   barriers; depth 2–3 is the tuned range.
+4. **VNNI-pack B** and, for quantized weights, **fuse dequant into the reorder** (int4/e2m1/fp8
+   → bf16/half) so upconvert rides the load→MMA pipeline.
+5. **Respect 2D-block alignment** (base %64 B, width/pitch %4 B, dims ≤ 2²⁴) at the tensor level
+   or the fast copy path silently won't apply.
+6. **For ragged/grouped work (MoE), use a persistent atomic-counter scheduler**, and size the M
+   tile to the *average* tokens-per-expert, not the global M.
+7. **Fuse the elementwise neighbors into the matmul producer/consumer**: L2-norm into conv1d,
+   QK-norm into RoPE, SiLU·mul into the quant, decay-scale into the delta-rule GEMM.
+8. **Arch-gate**: BMG and PVC differ (e.g. the delta-rule inverse); keep a correctness fallback.
+
+---
+
+**Document version**: 1.1
+**Reference**: `vllm-project/vllm-xpu-kernels@main` + `intel/sycl-tla@cd763790`
+(`include/cute/{arch,atom}/*xe*`, `include/cutlass/gemm/{collective,kernel,dispatch_policy}` Xe,
+`csrc/xpu/{gdn_attn,attn,grouped_gemm,onednn,sycl}`, `csrc/moe`, `csrc/quantization/fused_kernels`)
 **Companion**: `QWEN3_5_ARCHITECTURE.md`

--- a/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
+++ b/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
@@ -651,8 +651,61 @@ load-imbalance and quantization are the Xe2-specific challenges.
 
 ---
 
-**Document version**: 1.1
+## 11. Two deeper mechanisms (read end-to-end)
+
+### 11.1 The quantized-expert mainloop — int4/MXFP4 MoE GEMM in detail
+`xe_mma_mixed_input.hpp` (`CollectiveMma<MainloopIntelXeXMX16MixedPrecision<Stages>, …>`) is the
+collective for Qwen3.5-MoE's int4/MXFP4/fp8 experts. It is the dense `xe_mma.hpp` pipeline plus
+an **in-register dequant stage**, with several bandwidth tricks:
+
+- **Dequant fused before each DPAS** (`operator()`, `:831-869`): per K-tile it does
+  `copy(quantized A/B → quant_frag)` → `transform_quant(quant_frag → mma_frag, scale, zero)` →
+  `cute::gemm(mma_A, mma_B, accum)`. `transform_quant` (`:503-620`) applies `(x − zero)·scale`
+  (groupwise) or `x·scale` (tensorwise) into the MMA fragment — so the 4-bit weight is upconverted
+  to the MMA dtype in registers immediately before the matrix multiply, never materialized in
+  memory.
+- **Group-strided scale/zero reload** (the key bandwidth win, `:840-849`): scales/zeros are
+  reloaded only every `k_reload_factor = group_size / BLK_K` K-tiles — i.e. only when the K-loop
+  crosses a quant-group boundary, not every iteration. For Qwen3.5-MoE `group_size = 32`, the
+  scale fragment is fetched ~`32/BLK_K`× less often than the weights.
+- **Bit-width-specialized scale/zero load atoms** (`scale_zero_copy_traits`, `:49-90`): 4-bit →
+  `XE_2D_Packed_U4x1x128_LD_N` (8 int4 along K packed into one int32, N-major); 8/16/32-bit
+  variants. Zero-points are packed along K (`zero_elements_packed_along_k`) and unpacked
+  in-register. Scales are broadcast across lanes with `shfl_sync` (`:576`) — a 1×32 scale atom
+  yields 2 values reused per subgroup, avoiding redundant global loads.
+- **FP8 path**: `convert_FP8_to_FP16` (`:534`) for the e4m3/e5m2 expert variant.
+- Everything else (prefetch `Stages` ahead, split barriers, VNNI reorder) is shared with the
+  dense mainloop. Net: the int4 MoE expert GEMM costs ~the same global-memory traffic as a
+  4-bit-weight matmul, with dequant hidden in the register pipeline and scale traffic amortized
+  over the quant group.
+
+### 11.2 Stream-K / split-K scheduling — filling the machine on small GEMMs
+`xe_persistent_tile_scheduler_params_streamk.hpp` + `kernel/xe_tile_scheduler_streamk.hpp` add a
+**K-splitting** scheduler, complementary to the MoE atomic-counter scheduler (§10.3):
+
+- **Problem**: data-parallel tiling gives one output tile per workgroup. When `#(M·N tiles) <
+  #Xe-cores` the GPU underfills and tail effects dominate — exactly Qwen3.5 **decode** (M = 1
+  token), the **GDN** linear-attention per-head matmuls (small M/N, work is in K = head/state
+  dim), and MoE experts with few tokens.
+- **DecompositionMode** (`:76-85`): `Heuristic` (pick automatically from tiles-vs-units),
+  `DataParallel` (one tile/WG), `SplitK` (fixed `splits`), `StreamK` (fine-grained K split).
+- **Stream-K mechanism**: the K-iteration space is divided across "units"; each computes a
+  *partial* accumulator into a `reduction_workspace_`, then partials are reduced. "Big units"
+  take one extra K-chunk to absorb the K residual (`big_units_`, `divmod_k_tiles_per_sk_unit_`,
+  `:110-130`). This converts idle cores on a skinny GEMM into parallel K-reducers.
+- **ReductionMode** (`:55-73`): `Deterministic` — turnstile lock, partials accumulated in K
+  order → reproducible FP; `Nondeterministic` — atomic accumulate without ordering → faster but
+  FP-rounding depends on order. A port must pick per the reproducibility requirement.
+- **The three schedulers, when to use which**: *data-parallel* (enough tiles to fill the GPU —
+  large prefill GEMM); *stream-K / split-K* (too few tiles, large K — decode, GDN); *persistent
+  atomic-counter* (`grouped_gemm`, §10.3 — many ragged independent problems, balance across the
+  M/expert dimension). Qwen3.5 touches all three across its layers and batch regimes.
+
+---
+
+**Document version**: 1.2
 **Reference**: `vllm-project/vllm-xpu-kernels@main` + `intel/sycl-tla@cd763790`
-(`include/cute/{arch,atom}/*xe*`, `include/cutlass/gemm/{collective,kernel,dispatch_policy}` Xe,
+(`include/cute/{arch,atom}/*xe*`, `include/cutlass/gemm/{collective,kernel,dispatch_policy}` Xe
+incl. `xe_mma.hpp`, `xe_mma_mixed_input.hpp`, `xe_*_tile_scheduler_streamk*`,
 `csrc/xpu/{gdn_attn,attn,grouped_gemm,onednn,sycl}`, `csrc/moe`, `csrc/quantization/fused_kernels`)
 **Companion**: `QWEN3_5_ARCHITECTURE.md`

--- a/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
+++ b/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
@@ -456,10 +456,60 @@ hardware block messages:
 `barrier_scope = 2` is `ScopeWorkgroup` (`:34-40`). (The FMHA mainloop additionally uses its own
 even-lower-level `sbarrier.signal/wait` + `lsc_fence.ugm` inline asm — see §8.1.)
 
+**Backend selection** (read in `mma_xe_legacy.hpp:38-42` + `xe_mma_builder.inl`): the legacy
+named atoms (`XE_8x16x16_F32BF16BF16F32_TT`, …, full MNK×dtype zoo in `mma_xe_legacy.hpp`)
+pick builtin-vs-SPIR-V **at compile time by oneAPI version** — `__INTEL_LLVM_COMPILER <
+20250200` (or `CUTLASS_SYCL_BUILTIN_ENABLE`) → OpenCL builtins, else SPIR-V intrinsic. But the
+**CollectiveBuilder always uses the modern inline-asm `XE_DPAS_TT`** via `xe_dpas_tt_op_selector`
+(`xe_mma_builder.inl:44-53`; `DPAS_M = gcd(8, TileM)`, up to 32 subgroups/WG). So the FMHA and
+generic GEMM paths get the vISA `dpas`, same as the GDN kernels.
+
+### 8.3 The rest of the lowering path (copy / reorder / barrier), read in full
+
+Completing the "don't skip anything" pass over every atom the vllm kernels call:
+
+- **2D block copies** = a split design: the **address payload descriptor** is built with
+  **Intel IGC builtins** `__builtin_IB_subgroup_createBlock2DAddressPayload(base, width-1,
+  height-1, pitch-1, x, y, blockW, blockH, count)` (`copy_traits_xe_2d.hpp:41-52, 147-162`),
+  and the **actual transfer** is the inline-vISA `lsc_{load,store}_block2d.ugm`
+  (`copy_xe_2d.hpp`). Per-copy, only x/y block offsets are mutated
+  (`setBlock2DAddressPayloadBlockX/Y`, `:164-190`); for >2D tensors the base ptr is bumped by
+  `inner_product(coord, tiled_strides)`. **Hardware constraints a port must honor**
+  (`:120-127`): base % 64 B, width % 4 B, pitch % 4 B, x-offset % 4, all dims ≤ 2²⁴; block
+  height ≤ 32 (load) / ≤ 8 (store); ≤ 4 blocks. `block_2d_selector` (`:652-725`) chooses
+  plain/VNNI/transpose: VNNI for 8/16-bit when the MMA consumer wants it, transpose for
+  significant transposition, block width = power-of-2 gcd ≤ 64 B, cache-line aware.
+- **`reorder()` = fused in-register dtype-convert + VNNI repack**, all hand-written vISA in
+  `reorder_xe.hpp` (1426 lines). Beyond plain layout shuffles (`reorder_atom_xe.hpp`'s generic
+  `mov` with strided GRF regions, classified UU/UV/VU/VV/Generic), it carries **dequant
+  sequences for every low-precision type**, each with documented cycle counts: int8/uint8 →
+  half/bf16, fp8 `e5m2`/`e4m3` → half/bf16, **int4/uint4 → half/bf16** (`shr` nibble-expand +
+  `bfn` boolean-func + `0xE4xx` half-bias), **`e2m1` (NVFP4/MXFP4 4-bit float) → half/bf16**,
+  and **`ue8m0` → float** (the MXFP4 shared-exponent **block-scale** decode). This is the
+  int4/mxfp4 MoE-expert dequant from §6, fused into the load→MMA pipeline — and the
+  `e2m1`/`ue8m0` paths are exactly the **NVFP4** decode Arcaine already implements by hand for
+  DiffusionGemma; sycl-tla has vISA reference sequences for them.
+- **1D copies** (`copy_xe.hpp`) are mixed: SLM load/store = inline-vISA `lsc_load.slm` /
+  `lsc_store.slm` (`XE_1D_LDSM`/`XE_1D_STSM`); global load/store = the **SYCL**
+  `group_load`/`group_store` experimental API (`XE_1D_LOAD/STORE_GLOBAL`); reductions =
+  `sycl::atomic_ref` (`XE_ATOMIC`, the grouped-GEMM `atomic_buffer`).
+- **Barriers** = SPIR-V split barriers `__spirv_ControlBarrier{Arrive,Wait}INTEL(scope,…)`
+  (`xe_split_barrier.hpp:52-80`); `barrier_scope = 2` = `ScopeWorkgroup`. The FMHA mainloop
+  drops even lower to raw `sbarrier.signal/wait` + `lsc_fence.ugm` asm (§8.1).
+- **Collective staging**: the default GEMM/FMHA `CollectiveBuilder` declares **no shared
+  memory** (`SmemLayoutAtom = void; // No shared memory usage`, `xe_mma_builder.inl:115-118`) —
+  it is **L1-staged** (`MainloopXeL1Staged<3>`; group/MoE = `…Group<2>`) with operands flowing
+  gmem→registers via 2D block loads + prefetch. SLM-staging helpers (`make_A_slm_copies`,
+  `make_slm_copy`, `copy_traits_xe_2d.hpp:1113-1355`) exist as an alternative but are not the
+  default path. (Contrast: the GDN delta-rule kernels *do* use SLM `local_accessor` for the
+  g/β/A scratch — §3.)
+
 **Net**: every "target" the vllm kernels lean on — the DPAS MMA, the 2D block loads/stores with
-VNNI, the prefetch, the split barriers — bottoms out in **inline GenISA/vISA assembly and
-`__spirv_*` intrinsics inside sycl-tla**, compiled for `intel_gpu_bmg_g21`. There is no
-`joint_matrix` anywhere in the path.
+VNNI, the in-register low-precision dequant, the prefetch, the split barriers — bottoms out in
+**inline GenISA/vISA assembly, Intel IGC `__builtin_IB_*` intrinsics, and SPIR-V `__spirv_*`
+intrinsics inside sycl-tla**, compiled for `intel_gpu_bmg_g21`. The only place the high-level
+SYCL parallelism API appears is 1D global `group_load`/`group_store` and `atomic_ref`. **There
+is no `joint_matrix` anywhere in the path** — confirmed by reading every atom file end to end.
 
 ---
 

--- a/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
+++ b/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
@@ -312,9 +312,10 @@ FetchContent from `github.com/intel/sycl-tla` (`CMakeLists.txt:339-371`).
 `cute::gemm` are **defined in the sycl-tla dependency, not in this repo** (sycl-tla is not
 vendored in the source tree — it is fetched during the build). So whether the final lowering
 emits the SYCL `joint_matrix` intrinsics or targets the DPAS instruction through another path
-is a property of sycl-tla that **cannot be determined from this repository alone**. What is
-verifiable here: the application kernels program the matrix engine exclusively through cute
-atoms. The stack is:
+is a property of sycl-tla. **This is now resolved in §8.2** by reading `intel/sycl-tla` at the
+pinned revision directly: the answer is **inline vISA assembly**, not `joint_matrix`. What is
+verifiable in *this* repo: the application kernels program the matrix engine exclusively through
+cute atoms. The stack is:
 
 ```
 cute::gemm(mma, A, B, C)                       # issue
@@ -388,6 +389,77 @@ prefetch pipeline by hand. The repo deliberately chose (a); the `WGTile`/`SGLayo
 §3.3 are the tuned configuration you'd otherwise have to rediscover. Note oneDNN (option in
 §7) hides DPAS entirely behind its matmul primitive — for plain projections that's the least
 work.
+
+### 8.2 Resolved: how SYCL-TLA actually emits DPAS (read from `intel/sycl-tla`)
+
+Pulled `intel/sycl-tla` at the revision vllm-xpu-kernels pins
+(`CUTLASS_REVISION = cd763790ad2f74d7294435ecf77682bac0062c3a`, `CMakeLists.txt:322-324`;
+default target `intel_gpu_bmg_g21` = Battlemage, `:359-361`) and read the atom headers in full.
+**`grep joint_matrix include/` across all of sycl-tla returns zero — the SYCL `joint_matrix`
+C++ API is never used.** Instead there are **three** DPAS backends, all reaching the hardware
+without `joint_matrix`:
+
+1. **Modern `XE_DPAS_TT` — inline vISA/GenISA assembly** (`include/cute/arch/mma_xe.hpp:78-115`).
+   This is the atom vllm-xpu-kernels instantiates (`XE_DPAS_TT<8, float, …>`). The `fma`
+   emits a raw `asm` block:
+   ```
+   dpas.<TB>.<TA>.8.<M> (M1, 16) DST.0 SRC0.0 SRC1_UD.0 SRC2_UD(0,0)
+   ```
+   - `.8.` = **systolic depth 8** (8 K-substeps per issue); `(M1, 16)` = SIMD-16 exec
+     (one **subgroup of 16** lanes executes one DPAS); `M` = repeat count (rows).
+   - Two forms: accumulate-in-place (`C==D`, `DST.0 DST.0 …`) and separate-C
+     (`DST.0 SRC0.0 …`), `mma_xe.hpp:91-113`.
+   - A/B operands aliased as **UD (uint32)** registers → the VNNI-packed layout the systolic
+     array consumes. On non-Xe targets the atom is a `CUTE_INVALID_CONTROL_PATH` (`:127-130`).
+   - Supported dtypes (`:135-169`): tf32, **bf16, fp16** (fp32 or same-type accumulate), int8,
+     **int4**, and mixed int8×int4 — this is what backs the bf16/fp16 attention GEMMs and the
+     int4/mxfp4 MoE experts.
+2. **Legacy builtin** (`mma_xe_legacy_builtin.hpp`): OpenCL-style subgroup matrix-MAD builtins
+   `intel_sub_group_bf16_bf16_matrix_mad_k16` / `…_f16_f16_…_k16` / `…_i8_i8_…_k32` /
+   `…_tf32_tf32_…_k8` (`:35-58`). Note `k16`/`k32`/`k8` = the K depth per dtype. One case
+   (fp16-acc-fp16) is commented "*builtins do not work*" and falls back to SPIR-V (`:65-69, 116`).
+3. **Legacy SPIR-V** (`mma_xe_legacy_spirv.hpp`): the
+   `__spirv_SubgroupMatrixMultiplyAccumulateINTEL` cooperative-matrix intrinsic (`:34-62`) with
+   an operand-flags struct (`SPIRV_MatrixABf16`, `…Int8`, `…Tf32`, signedness, …, `:64-76`).
+   **This is the same SPIR-V instruction the high-level `joint_matrix` API also lowers to — but
+   sycl-tla calls the `__spirv_*` intrinsic directly, skipping the C++ matrix API.**
+
+So for Arcaine the precise answer is: the DPAS path is **not** `joint_matrix`. The production
+atom is **hand-written vISA `dpas`**; sycl-tla keeps SPIR-V-intrinsic and OpenCL-builtin atoms
+as alternates. If Arcaine wants the same instruction without depending on sycl-tla, the
+portable route is the `__spirv_SubgroupMatrixMultiplyAccumulateINTEL` intrinsic (or
+`joint_matrix`, which lowers to it); the max-control route is the inline `dpas` asm.
+
+**MMA atom shape/layout** (`mma_traits_xe.hpp`):
+- `Shape_MNK = (M, 16, K)`; **N is fixed at 16** (= subgroup width); `K = 256 /
+  max(bits(A),bits(B))` → **16 for bf16/fp16, 32 for int8, 64 for int4, 8 for tf32**
+  (`mma_xe.hpp:50`, `mma_traits_xe.hpp:70-80`).
+- `ThrID = SGSize (16)` → **one subgroup = one DPAS**; the GDN/GEMM `SGLayout` policies (§3.3)
+  replicate this atom across 2×2 / 2×1 / 4×2 subgroups.
+- **B is VNNI-transformed** (`BLayout`, `:87-90`), pack factor `BV = 32/bits(B)` (2 for 16-bit,
+  4 for 8-bit). A and C are work-item-interleaved row-major (`:83-94`).
+
+**The 2D block copies are also inline vISA** (`copy_xe_2d.hpp`), the LSC (Load-Store-Cache)
+hardware block messages:
+- `XE_LOAD_2D` → `lsc_load_block2d.ugm … nn` (plain), `XE_LOAD_2D_VNNI` → `… nt` (the `t` =
+  VNNI transform, restricted to 8/16-bit B operands), `XE_LOAD_2D_TRANSPOSE` → `… tn`
+  (32/64-bit) (`:82-138`).
+- `XE_PREFETCH_2D` → `lsc_load_block2d.ugm.ca.ca … %null` — the software prefetch is a cached
+  (`.ca.ca` = L1+L3) 2D block load to the null register (`:146-151`); this is the
+  `prefetch_dist=3` pipeline in §3.3/§8.1.
+- `XE_STORE_2D` → `lsc_store_block2d.ugm` (height ≤ 8) (`:160-178`). Hardware limits are
+  asserted in `XE_Copy_Op_2D_Base` (height ≤ 32 load, Bits·Width ≤ 512, block count ≤ 4≠3,
+  `:55-68`).
+
+**Barriers are SPIR-V split barriers** (`xe_split_barrier.hpp`): `barrier_arrive`/`barrier_wait`
+→ `__spirv_ControlBarrier{Arrive,Wait}INTEL(scope, …)` (`:52-80`); the GDN GEMM's
+`barrier_scope = 2` is `ScopeWorkgroup` (`:34-40`). (The FMHA mainloop additionally uses its own
+even-lower-level `sbarrier.signal/wait` + `lsc_fence.ugm` inline asm — see §8.1.)
+
+**Net**: every "target" the vllm kernels lean on — the DPAS MMA, the 2D block loads/stores with
+VNNI, the prefetch, the split barriers — bottoms out in **inline GenISA/vISA assembly and
+`__spirv_*` intrinsics inside sycl-tla**, compiled for `intel_gpu_bmg_g21`. There is no
+`joint_matrix` anywhere in the path.
 
 ---
 

--- a/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
+++ b/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
@@ -300,10 +300,21 @@ Patterns that recur and are worth standardizing in Arcaine's kernel layer:
 
 ### 8.1 Matrix-engine (DPAS) programming model — and the `joint_matrix` question
 
-**The matrix-multiply work does *not* use the SYCL `joint_matrix` API directly.** A grep for
-`joint_matrix` across `csrc/` returns **zero** hits. Instead, every matmul-shaped kernel
-(GDN delta rule, grouped GEMM, FMHA) drives the Xe **DPAS** (Dot-Product-Accumulate-Systolic)
-units through **CUTLASS-SYCL's `cute` MMA abstraction**. The stack is:
+**Verified by reading the matrix kernels in full** (`gdn_attn/xe_2/gemm.hpp` 1–490,
+`chunk_gated_delta_rule_kernels_xe2.hpp` 1–1631, `grouped_gemm/xe_2/grouped_gemm_xe2_interface.hpp`
+1–372, `attn/xe_2/collective/chunk_prefill_mainloop.hpp`): **none of this repo's kernels call
+the SYCL `joint_matrix` API directly.** Every matmul-shaped kernel (GDN delta rule, grouped
+GEMM, FMHA) drives the Xe **DPAS** (Dot-Product-Accumulate-Systolic) units through the **`cute`
+MMA abstraction from SYCL-TLA** — Intel's CUTLASS-for-SYCL, pulled at build time via
+FetchContent from `github.com/intel/sycl-tla` (`CMakeLists.txt:339-371`).
+
+**Important boundary**: the DPAS *atom* (`XE_DPAS_TT`), the 2D-block copy atoms, and
+`cute::gemm` are **defined in the sycl-tla dependency, not in this repo** (sycl-tla is not
+vendored in the source tree — it is fetched during the build). So whether the final lowering
+emits the SYCL `joint_matrix` intrinsics or targets the DPAS instruction through another path
+is a property of sycl-tla that **cannot be determined from this repository alone**. What is
+verifiable here: the application kernels program the matrix engine exclusively through cute
+atoms. The stack is:
 
 ```
 cute::gemm(mma, A, B, C)                       # issue
@@ -347,8 +358,25 @@ using MMA = TiledMMAHelper<MMA_Atom<decltype(op)>,
 - **int4 experts** go through a specialized caller `XE_GEMM_4BITS_CALLER(GroupSize)` for
   group sizes 32/64/128/256 (`grouped_gemm_xe2.hpp:178-196`) — same DPAS atom, with an
   in-fragment dequant of the 4-bit B operand against `ptr_scales`.
-- **Arch gating**: some MMA shapes are taken only on Battlemage (`if (vllm::xpu::is_bmg())`
-  selects the 16³ inverse MMA, `chunk_gated_delta_rule_kernels_xe2.hpp:1348`).
+- **Arch gating with a correctness workaround**: the chunked delta rule launches **five**
+  kernels — `chunk_prepare` (decay cumsum), `chunk_compute_A`, the triangular **inverse**,
+  `chunk_compute_wu`, `chunk_fwd_o` (`kernel_launcher`, `:1249-1501`). The inverse has **two
+  implementations chosen at runtime**: on Battlemage (`is_bmg()`) a blocked 4×4 DPAS inverse
+  using 16×16 MMA tiles (`chunk_inverse_opt_kernel`, `:388`, `:1348`); on PVC a **native
+  non-MMA SLM kernel** because "PVC has acc issue of sycl tla" for this op (`:1382-1411`). A
+  port must keep the same numerically-stable fallback option.
+- **Register-sharing fusions** (read in `gemm.hpp`): `gemm_TTS_fused_2A` (`:381-489`) issues
+  two DPAS ops sharing one B fragment in registers — used in `chunk_fwd_o` to compute `W×S` and
+  `Q×S` from a single `S[dv]` load (`:1106-1123`); `gemm_TTS_k_multi` (`:282-379`) folds a
+  per-K scale vector (`beta`/`g`) into the A fragment before the MAD.
+- **FMHA uses two DPAS tilings**: `chunk_prefill_mainloop.hpp` is templated on `TiledMMAQK_`
+  (Q·K) and `TiledMMAPV_` (P·V) separately (`:73-74`), the classic flash-attention two-GEMM
+  pipeline with "P in registers" (`XeDefault<Stages>`, `:46-47`), synchronized with raw
+  inline-asm split barriers `sbarrier.signal/wait` + `lsc_fence.ugm` (`:53-62`).
+- **Grouped-GEMM tile policy is chosen by average tokens-per-expert**: `A_avg_M = total_M /
+  num_experts` selects `w{4,8,16}a16_policy_m_{8,16,32}` (and by N for w16a16)
+  (`grouped_gemm_xe2_interface.hpp:287-368`) — small per-expert batches (MoE decode) use
+  M-skinny tiles. int4 packs 2 weights/byte (`B_K = size(2)*2`, `:203-205`).
 
 **Why it matters for Arcaine**: if you want the same DPAS throughput you have two options —
 (a) depend on CUTLASS-SYCL `cute` and reuse these `XE_DPAS_TT` atoms + tile policies verbatim

--- a/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
+++ b/notes/qwen3_5/QWEN3_5_XPU_KERNELS.md
@@ -1,0 +1,402 @@
+# vllm-xpu-kernels: SYCL/Xe Kernel Optimizations for the Qwen3.5 Path
+
+**Source**: `github.com/vllm-project/vllm-xpu-kernels` @ `main` (fetched into this env).
+**Companion to**: `QWEN3_5_ARCHITECTURE.md` — that doc describes the PyTorch reference and the
+CUDA fast path; this one maps each Qwen3.5 component to an **existing Intel-GPU SYCL kernel**
+and extracts the optimization techniques worth reusing in Arcaine.
+
+> This is the most directly relevant prior art for Arcaine: it is SYCL/DPC++ + **oneDNN**,
+> targets **Battlemage** (Xe2) and PVC, uses CUTLASS-SYCL (`cute`) with DPAS matrix engines,
+> and already implements the exact GatedDeltaNet + MoE + paged-attention stack Qwen3.5 needs.
+> Citations are `path:line` inside the vllm-xpu-kernels tree.
+
+---
+
+## Table of Contents
+
+1. [What this repo is](#1-what-this-repo-is)
+2. [Component → kernel map](#2-component--kernel-map)
+3. [Gated DeltaNet (linear attention) — the crown jewel](#3-gated-deltanet-linear-attention--the-crown-jewel)
+4. [Full attention: FMHA chunk-prefill + paged-decode](#4-full-attention-fmha-chunk-prefill--paged-decode)
+5. [Fused QK-norm + RoPE, and M-RoPE](#5-fused-qk-norm--rope-and-m-rope)
+6. [MoE: grouped GEMM + routing kernels](#6-moe-grouped-gemm--routing-kernels)
+7. [oneDNN matmul integration (quantized GEMM)](#7-onednn-matmul-integration-quantized-gemm)
+8. [Cross-cutting Xe2 techniques](#8-cross-cutting-xe2-techniques)
+9. [Reuse guidance for Arcaine](#9-reuse-guidance-for-arcaine)
+
+---
+
+## 1. What this repo is
+
+A PyTorch-custom-op extension that registers XPU kernels into the dispatcher
+(`import vllm_xpu_kernels._C`). Written in **SYCL/DPC++ + oneDNN**, built with CMake/Ninja,
+oneAPI 2025.3, PyTorch 2.12+xpu (`README.md`). Two relevant build dimensions:
+
+- **Arch tiers** gated by `VLLM_XPU_ENABLE_XE2` (`gdn_attn_interface.cpp:9`) and runtime
+  device probes `is_bmg_g21` / `is_bmg_g31` / `is_bmg` / `is_pvc`
+  (`csrc/xpu/torch_bindings.cpp:116-125`). **BMG = Battlemage (Xe2)**, the Arcaine target;
+  PVC = Ponte Vecchio (Xe-HPC). The high-perf kernels live under `csrc/xpu/*/xe_2/`.
+- **Compile-time attention-variant selection** (`KERNEL_CONFIGURATION.md`): chunk-prefill and
+  paged-decode kernels are templated on `(headsize, paged, causal, local, sink, lse)` /
+  `(qgroup, headsize, pagesize, causal, local, sink)` and only the listed tuples are built.
+  The "default" preset explicitly covers **Llama / Qwen / DeepSeek**. Lesson for a from-scratch
+  port: these axes are the real specialization surface — head size, causal, **sliding-window
+  ("local")**, **attention sink**, and **LSE** output are separate compiled variants, not
+  runtime branches.
+
+Registered op surface relevant to Qwen3.5 (`csrc/xpu/torch_bindings.cpp`):
+`gdn_attention`, `cutlass_grouped_gemm_interface`, `apply_rotary_emb`,
+`multimodal_rotary_embedding`, `deepseek_scaling_rope`, `topk_topp_sampler`, plus the oneDNN
+GEMMs `fp8_gemm`, `fp8_gemm_w8a16`, `fp4_gemm`, `int4_gemm_w4a16`, `int4_gemm_w4a8`
+(`:14-38`). Note: the **fused QK-norm+RoPE** kernel lives in the common `csrc/` bindings, not
+the XPU-only table.
+
+---
+
+## 2. Component → kernel map
+
+| Qwen3.5 component (from architecture doc) | vllm-xpu-kernels source | Technique headline |
+|---|---|---|
+| `Qwen3_5GatedDeltaNet` (linear attention) | `csrc/xpu/gdn_attn/` (whole dir) | conv1d + chunked delta rule on DPAS; decode/prefill/spec split |
+| └ depthwise causal Conv1d (`causal_conv1d`) | `gdn_attn/xe_2/chunk_causal_conv1d_{,tiled_}xe2.hpp` | SLM-staged, tiled vs untiled by token count; fused l2norm |
+| └ chunked gated delta rule | `gdn_attn/xe_2/chunk_gated_delta_rule_kernels_xe2.hpp` (+ `gemm.hpp`) | `chunk_size=64`, CUTLASS-SYCL `cute` MMA tiles |
+| └ q/k L2-norm | `gdn_attn/xe_2/l2norm_kernel.hpp` | fused into conv1d when dims fit, else standalone |
+| └ single-token decode recurrence | `gdn_attn/gated_delta_rule.hpp` (native) | per-step state update, no chunking |
+| `Qwen3NextAttention` (full attention, GQA) | `csrc/xpu/attn/xe_2/{chunk_prefill,paged_decode}*` | paged-KV FMHA, varlen, local/sink/lse |
+| └ QK-norm + partial RoPE | `csrc/fused_qknorm_rope.cpp` | one kernel: RMSNorm(head) + RoPE |
+| M-RoPE (3D interleaved) | `csrc/xpu/sycl/multimodal_rope.cpp` | section-cumsum lookup, vec4 |
+| RoPE (NeoX/GPT-J) | `csrc/xpu/sycl/{apply_rotary_emb,rotary_embedding.hpp}` | |
+| `Qwen3_5MoeSparseMoeBlock` experts | `csrc/xpu/grouped_gemm/` (+ `csrc/moe/`) | CUTLASS grouped GEMM, int4/mxfp4 experts |
+| └ router top-k (softmax/sigmoid) | `csrc/moe/topk.cpp`, `grouped_topk.cpp` | subgroup-reduction scoring |
+| └ permute / scales / scatter | `csrc/moe/{fused_moe_prologue,moe_align_sum_kernels,moe_gather,remap_hidden_states}.cpp` | gather/scatter without host sync |
+| Quantized projections (w8a8/w8a16/w4a16/w4a8/fp4) | `csrc/xpu/onednn/*_gemm_*.h` + `onednn_matmul.cpp` | oneDNN matmul primitives + cache |
+| Vision encoder | *(no Qwen3-VL-specific kernel)* | reuse FMHA (non-causal varlen) + oneDNN GEMM |
+
+Two gaps to note up front: (a) there is **no DeltaNet/Mamba backward** here (inference repo,
+same as the CUDA libs); (b) there is **no vision-tower-specific kernel** — the ViT would reuse
+the generic varlen FMHA + GEMMs.
+
+---
+
+## 3. Gated DeltaNet (linear attention) — the crown jewel
+
+`gdn_attention` (`gdn_attn/gdn_attn_interface.cpp:16-66`) is a near-1:1 match to the Qwen3.5
+`Qwen3_5GatedDeltaNet.forward`. Its tensor contract names the exact reference tensors:
+`projected_states_qkvz`, `projected_states_ba`, `conv_state` (`[batch, width-1, conv_dim]`),
+`ssm_state` (= the recurrent state, `[batch, num_v_heads, head_v_dim, head_k_dim]`),
+`conv_weights`, `A_log`, `dt_bias`, `activation` (`:16-66`). It even accepts the **interleaved
+`qkvz`/`ba` layout** (Qwen3-Next packing) and does the `fix_query_key_value_ordering` split
+**inside** the conv1d kernel, rather than as separate projections.
+
+### 3.1 Three execution regimes (matches the reference's cache-state branching)
+
+The interface splits work into **prefill / decode / spec-decode** and chooses a path
+(`:279-525`):
+
+- **Prefill (chunked), `num_prefills>0`, XE2**: `chunk_causal_conv1d_*_xe2` →
+  (optional standalone `l2norm`) → `chunk_gated_delta_rule_xe2` (`:410-518`). This is the
+  `torch_chunk_gated_delta_rule` analogue.
+- **Decode / small (`NATIVE_LAUNCHER`)**: `gdn::causal_conv1d` + `gdn::gated_delta_rule`
+  native kernels (`:342-402`) — the per-step recurrence (`torch_recurrent_gated_delta_rule`
+  analogue).
+- **Speculative decode (`spec_token>0`)**: same two native calls but driven by
+  `spec_*` index tensors and `num_accepted_tokens` (`:279-339`) — a vLLM feature with no
+  transformers analogue; safe to ignore for a first Arcaine port.
+
+The chunk-vs-native switch is purely a **token-count heuristic**:
+`use_tiled = non_spec_token >= conv1d_tile_size` and the chunk path only runs when
+`num_prefills>0` (`:441, 410`). Decode (1 token/seq) always takes the native recurrence.
+
+### 3.2 Causal Conv1d — two SLM-staged variants
+
+`chunk_size_xe2 = 64` (`gdn_attn_utils.h:8`) — **identical to the reference `chunk_size=64`**.
+
+**Tiled** (`chunk_causal_conv1d_tiled_xe2.hpp`): the high-throughput prefill conv.
+- `wg_size=64` (4 subgroups × `sub_group_size=16`), `elems_per_item=4` →
+  **`feats_per_wg = 256` features per workgroup** (`:30-32, 123`).
+- Grid `(num_tiles * num_feat_chunks, num_k_heads)`, tile length `conv1d_tile_size=8`
+  (`:10, 18`). The conv channels (8192 in Qwen3.5) are split into 256-wide feature chunks so
+  a WG holds its slice in **SLM**: `slm_data_elems = (TileT + Width - 1) * feats_per_wg`
+  staging the conv window + left-context halo, plus `slm_meta` (5 ints) and a `norm_slm`
+  region (`:119-127`). This is the in-kernel realization of the reference's "prepend conv_state
+  / left-pad" logic — the halo of `Width-1` rows is the rolling `conv_state`.
+- **Fused l2norm**: when `2*head_k_dim <= feats_per_wg (256)` the Q/K L2-norm is folded into
+  the conv epilogue (`fuse_l2norm`, interface `:439-443, 469`); otherwise a standalone
+  `l2norm` kernel runs (`:498-500`). For Qwen3.5 `head_k_dim=128` → `2*128=256 ≤ 256`, so
+  **l2norm fuses** in the tiled path. Worth replicating: it removes a full-tensor round trip.
+- Width is a compile-time template (`TILED_WIDTH_DISPATCH` for width 1–5,
+  `chunk_causal_conv1d_tiled_xe2.hpp:834-849`) and `reorder_input` is a second template axis
+  (`:855-859`) — kernel specialization over the kernel size (4 for Qwen3.5) and input layout.
+
+**Untiled** (`chunk_causal_conv1d_xe2.hpp`): `sub_group_size=32`, `elems_per_item=4`, entire
+QKV of a token-group in one WG (`:14-15`); used for small token counts where tiling overhead
+dominates. l2norm always fuses here (interface `:442-443`).
+
+### 3.3 Chunked gated delta rule on DPAS
+
+`chunk_gated_delta_rule_kernels_xe2.hpp` is CUTLASS-SYCL (`cute`) (`:33-53`). Key points for a
+port:
+
+- **On-device decay**: `chunk_prepare_kernel` computes
+  `g = -exp(A_log) * softplus(a + dt_bias)` in fp32 (`act_softplus` with the `>20` linear
+  cutoff, `:44-50`; applied `:78-110`) — exactly the reference formula and the same fp32
+  requirement flagged in the architecture doc.
+- **Four GEMM tile policies** (`:19-42`) map to the four matmuls of the chunked algorithm:
+  - `compute_A` = `64x64x32` SG layout `2x2` — the intra-chunk `K·Kᵀ` attention matrix.
+  - `inverse` = `16x16x16` — the lower-triangular `(I − tril)⁻¹` solve (the reference's
+    sequential forward-substitution loop, done here as a small dense inverse).
+  - `compute_wu` = `64x64x32` `2x1` — the `W`/`U` (k_cumdecay, v_new) products.
+  - `fwd_o` = `64x64x32` `4x2` — the forward output `q·state + attn·v_new`.
+- DPAS via `TiledMMA` + `partition_sg_fragment_{A,B}` and **block-2D loads with software
+  prefetch depth 3** and `barrier_arrive`/`barrier_scope` double-buffering
+  (`gemm.hpp:60-130`). This is the standard cute pipeline; the takeaway is that the delta-rule
+  inner products are cast as **bf16/fp16 DPAS GEMMs** with an fp32 accumulator, not scalar
+  loops.
+- Chunk padding: the interface pads work to a multiple of `chunk_size_xe2` per sequence
+  (`padding_size = batch_size*(chunk_size_xe2-1)`, allocates zero-padded q/k/v, `:411-433`) and
+  carries `b`/`a` as **fp32** `[num_v_heads, tokens]` (transposed vs q/k/v) (`:428-433`).
+- **No host gather/scatter**: an optional `token_indx_ptr` lets the kernels read
+  `mixed_qkvz`/`mixed_ba` and write `z`/`core_attn_out` at interleaved global slots directly
+  (`:404-409, 414-417`).
+
+### 3.4 Native (decode) recurrence
+
+`gated_delta_rule.hpp` (833 lines) + `causal_conv1d.hpp` (1144 lines) implement the
+single-token path: `causal_conv1d_update`-style in-place ring-buffer conv-state update, then
+the per-step `S = S·exp(g); kv=(S·k).sum; Δ=(v−kv)β; S+=k⊗Δ; out=(S·q).sum`. These are the
+files to port first for a correctness baseline (they're scalar/subgroup, no cute/DPAS).
+
+---
+
+## 4. Full attention: FMHA chunk-prefill + paged-decode
+
+`csrc/xpu/attn/xe_2/` is a CUTLASS-SYCL flash-attention with **paged KV cache**. Signature
+(`fmha_xe2.h`, `cutlass_chunk_prefill_xe2`):
+`query[seq_q,heads,hd]`, `key_cache/value_cache[num_block,block_size,heads,hd]`, `block_table`,
+`cu_seqlens_q/k`, `k_scale/v_scale` (fp8 KV), `sm_scale`, `sm_sink`, `window_size_left/right`,
+flags `is_varlen/paged/causal/local/sink`, optional `softmax_lse` (`fmha_xe2.h:3-26`).
+
+What maps to Qwen3.5 full-attention layers:
+- **GQA** via `qgroup` (paged-decode config axis, `KERNEL_CONFIGURATION.md`); Qwen3.5 dense
+  is 16 Q : 4 KV.
+- **`is_local` + `window_size_left/right`** is sliding-window attention — not used by Qwen3.5
+  (its full layers are global) but present for Qwen2.5/Gemma-style models.
+- **`is_sink` + `sm_sink`** = attention sinks; **`softmax_lse`** = log-sum-exp output for
+  splitting/merging (`csrc/attention/merge_attn_states.cpp` merges partial softmax states).
+- **fp8 paged KV** via `k_scale`/`v_scale` — dequant in the mainloop.
+- Files: `kernel/chunk_prefill_kernel.hpp`, `kernel/paged_decode_kernel.hpp`,
+  `collective/chunk_prefill_{mainloop,epilogue,scheduler}.hpp` — the usual cutlass collective
+  split (tile scheduler + mainloop + epilogue).
+
+Note the output gate `attn * sigmoid(gate)` and QK-norm that Qwen3-Next adds are **not** inside
+this FMHA — they're applied by the caller (gate) and by `fused_qknorm_rope` (norm). A port must
+keep those outside the attention kernel, as the reference does.
+
+---
+
+## 5. Fused QK-norm + RoPE, and M-RoPE
+
+`csrc/fused_qknorm_rope.cpp` is a direct match to the Qwen3 full-attention preamble (QK-norm +
+RoPE), ported from a CUDA kernel (`:1-3`). One kernel, one pass over the fused QKV buffer:
+- `SUB_GROUP_SIZE=32`, `NUM_ELEMS_PER_THREAD = head_dim/32`, requires `head_dim % 64 == 0`
+  (`:24-27`) — Qwen3.5 `head_dim=256` ✓.
+- One **subgroup per (token, qk-head)**: `global_sg_id` decodes to `(token_idx, head)` and
+  splits Q vs K by `local_head_idx < num_heads_q` (`:55-66`). Each subgroup RMS-normalizes its
+  head (lane holds `head_dim/32` elems, subgroup-reduces the sum-of-squares) then applies RoPE
+  from `cos_sin_cache[position_ids]` — fusing the two head-dim reductions the reference does
+  separately (`q_norm`, then `apply_rotary_pos_emb`). `IS_NEOX` is a template axis.
+- V heads are skipped (only Q/K normalized+rotated), matching the reference.
+
+**M-RoPE** `csrc/xpu/sycl/multimodal_rope.cpp` matches the Qwen3.5 interleaved 3D RoPE:
+- `MROPE_MAX_SECTIONS=4`; precomputes cumulative `section_end[]` from `mrope_section`
+  (`:11-51`) so each rotary index does an O(sections) lookup to pick the temporal/height/width
+  frequency band — the kernel-side version of `apply_interleaved_mrope`.
+- `VEC_SIZE=4`, GPT-J/NeoX template; processes 2 rotation offsets per vec4 (`:53-55`).
+`deepseek_scaling_rope.cpp` is the YaRN/scaling variant (not needed for Qwen3.5 defaults).
+
+---
+
+## 6. MoE: grouped GEMM + routing kernels
+
+For `Qwen3_5MoeSparseMoeBlock` (256 experts, top-8, shared expert):
+
+**Grouped GEMM** `cutlass_grouped_gemm_interface` (`grouped_gemm/grouped_gemm_interface.h`):
+```
+ptr_A, ptr_B, ptr_scales?, ptr_bias?, ptr_D, rows_per_expert, N, K, num_experts,
+is_B_int4, is_B_mxfp4
+```
+- One batched/grouped GEMM over **all experts**, driven by `rows_per_expert` (the token counts
+  after routing) — this is the fused replacement for the reference's Python "loop over hit
+  experts." Implemented in `xe_2/grouped_gemm_xe2.*` (cutlass) and a `xe_default` fallback.
+- **Quantized experts built in**: `is_B_int4` / `is_B_mxfp4` with `ptr_scales` — i.e. the 3D
+  packed expert weights can be int4 or MXFP4, dequantized in the GEMM. The cutlass collective
+  (`collective/gemm/moe_*`) carries a dtype policy + callbacks + array-mma + tile scheduler
+  specialized for the ragged per-expert tile counts.
+
+**Routing / scatter kernels** (`csrc/moe/`):
+- `topk.cpp` — softmax **and** sigmoid scoring (`sigmoid_typed`, custom transposable softmax,
+  `:17-26`), top-k via subgroup reductions (`reqd_sub_group_size(WARP_SIZE)`, `:43-44`). Covers
+  both Qwen (softmax→topk→renorm) and DeepSeek (sigmoid) routers.
+- `grouped_topk.cpp` / `fused_grouped_topk` — group-limited routing (DeepSeek-V2/3 expert
+  groups); Qwen3.5 uses plain top-k but the kernel is a superset.
+- `fused_moe_prologue.cpp` — fuses permutation + scale gather into a workspace
+  (`token_selected_experts`, `token_final_scales`, `:6-11`) so the GEMM reads contiguous
+  per-expert blocks.
+- `moe_align_sum_kernels.cpp` (align token counts to tile size), `moe_gather.cpp`,
+  `remap_hidden_states.cpp`, `init_expert_map.cpp` — the gather/scatter plumbing that keeps the
+  whole route→GEMM→unroute pipeline on-device.
+
+The shared expert and its `sigmoid(shared_expert_gate)` gate have no dedicated kernel — they're
+a normal dense GEMM + activation (reuse oneDNN matmul + the SiLU-mul activation kernels in
+`csrc/activation.cpp` / `csrc/quantization/fused_kernels/fused_silu_mul_*`).
+
+---
+
+## 7. oneDNN matmul integration (quantized GEMM)
+
+`csrc/xpu/onednn/` is the most directly liftable piece for Arcaine, since Arcaine is already
+oneDNN-based. `onednn_matmul.cpp` + headers expose:
+- `fp8_gemm` (w8a8), `fp8_gemm_w8a16`, `fp4_gemm` (w4a4 / NVFP4-style with A_scale+B_scale),
+  `int4_gemm_w4a16`, `int4_gemm_w4a8` (`torch_bindings.cpp:14-38`,
+  headers `fp8_gemm_w8a8.h`, `fp8_gemm_w8a16.h`, `fp4_gemm_w4a4.h`, `int4_gemm_w4a16.h`,
+  `int4_gemm_w4a8.h`).
+- 2D/3D inputs, 2D weights; int4 weights required in **NT format** (`onednn_matmul.cpp:23-28`);
+  default out dtype fp16 (`:48`).
+- `onednn_runtime.{h,cpp}` + `lru_cache.h` — a **primitive/descriptor LRU cache** so repeated
+  GEMM shapes don't re-create oneDNN primitives. `onednn_ext.h` wraps engine/stream from the
+  SYCL queue.
+
+This is exactly the W4A16/W8A16/NVFP4 matmul surface Arcaine already wants (the README lists
+NVFP4 DiffusionGemma support) — the descriptor-cache pattern and the scale/zero-point wiring
+are reusable for Qwen3.5's quantized projections and MoE experts.
+
+---
+
+## 8. Cross-cutting Xe2 techniques
+
+Patterns that recur and are worth standardizing in Arcaine's kernel layer:
+
+1. **CUTLASS-SYCL (`cute`) for all matmul-shaped work** — DPAS `TiledMMA`, block-2D copies,
+   software prefetch (depth 3), `barrier_arrive` double-buffering (`gdn .../gemm.hpp:97-130`).
+   Reused for delta-rule, FMHA, and grouped GEMM.
+2. **Compile-time specialization over runtime branching** — kernel tuples templated on
+   head size / width / causal / local / sink / lse / dtype / NeoX, selected by config file
+   (`KERNEL_CONFIGURATION.md`; conv width dispatch `chunk_causal_conv1d_tiled_xe2.hpp:834-849`).
+3. **SLM staging with explicit halos** — conv windows + left-context loaded to shared local
+   memory; `(TileT + Width - 1) * feats_per_wg` sizing (`:124`).
+4. **Subgroup as the reduction unit** — `reqd_sub_group_size(16|32)`; one subgroup per
+   (token, head) for norm/RoPE; subgroup reductions for top-k and RMS.
+5. **Fuse adjacent elementwise reductions into the producer** — l2norm folded into conv1d when
+   dims fit (`gdn_attn_interface.cpp:439-443`); QK-norm folded into the RoPE kernel.
+6. **Index-tensor-driven gather/scatter, never host sync** — `token_indx`, `query_start_loc`,
+   `state_indices`, `rows_per_expert`, `block_table` thread the irregular work entirely on
+   device.
+7. **fp32 islands preserved** — decay `g`, softplus, RMS variance, router softmax all fp32 even
+   when activations are bf16/fp16 (`chunk_gated_delta_rule_kernels_xe2.hpp:44-50, 78-79`).
+8. **oneDNN primitive LRU cache** for shape-stable GEMMs (`onednn/lru_cache.h`).
+9. **Token-count heuristics pick the kernel** — tiled vs untiled conv, chunk vs native delta
+   rule (`gdn_attn_interface.cpp:441`), so prefill and decode hit different code without a
+   separate API.
+
+### 8.1 Matrix-engine (DPAS) programming model — and the `joint_matrix` question
+
+**The matrix-multiply work does *not* use the SYCL `joint_matrix` API directly.** A grep for
+`joint_matrix` across `csrc/` returns **zero** hits. Instead, every matmul-shaped kernel
+(GDN delta rule, grouped GEMM, FMHA) drives the Xe **DPAS** (Dot-Product-Accumulate-Systolic)
+units through **CUTLASS-SYCL's `cute` MMA abstraction**. The stack is:
+
+```
+cute::gemm(mma, A, B, C)                       # issue
+   └─ TiledMMA  =  TiledMMAHelper<             # tiling of the atom over the WG
+          MMA_Atom< XE_DPAS_TT<8, float, Elt> >,   # the DPAS atom
+          Layout<WGTile>,                      # e.g. Shape<_64,_64,_32>
+          SGLayout >::TiledMMA                 # e.g. Shape<_2,_2,_1> subgroups
+```
+
+Concretely (`chunk_gated_delta_rule_kernels_xe2.hpp:1275`,
+`grouped_gemm_xe2_interface.hpp:93`):
+```cpp
+auto op = XE_DPAS_TT<8, float, Element_non_CV>{};        // DPAS atom
+using MMA = TiledMMAHelper<MMA_Atom<decltype(op)>,
+                           Layout<WGTile>, SGLayout>::TiledMMA;
+```
+- **`XE_DPAS_TT<8, float, Elt>`** is the cute "atom" describing one DPAS instruction: systolic
+  **depth 8** (8 K-steps accumulated per issue), **fp32 accumulator** (`float`), and bf16/fp16
+  **input** element `Elt` (`Element_non_CV` = the non-const operand type). `TT` = both operands
+  row/transposed-major as the atom expects. This is the source-level handle to the same Xe
+  hardware instruction the SYCL `joint_matrix` API lowers to — cute just exposes it as a
+  typed atom rather than through `joint_matrix_load/mad/store`.
+- **`TiledMMAHelper<atom, WGTile, SGLayout>`** replicates the atom across a workgroup: `WGTile`
+  is the MNK macro-tile (`Shape<_64,_64,_32>` for the GDN compute GEMMs) and `SGLayout` is how
+  many **subgroups** cover M×N (`2x2`, `2x1`, `4x2`, or `1x1` for the 16³ inverse — see the
+  four policies in §3.3). `size(mma)` then gives the workgroup thread count used to launch
+  (`chunk_gated_delta_rule_kernels_xe2.hpp:1318`).
+- **Per-thread fragments**: `thr_mma.partition_sg_fragment_A/B(...)` allocate the register
+  fragments each work-item feeds to the atom; `cute::gemm(mma, tCrA, tCrB, tCrC)` issues the
+  DPAS over them (`gemm.hpp:88-92, 133`). The accumulator `tCrC` lives in registers across the
+  K-loop.
+- **Operand loads are 2D block loads with VNNI packing**, not scalar loads: the copy atoms are
+  `XE_LOAD_2D` / `XE_LOAD_2D_VNNI` and `XE_2D_U16x8x16_LD_N` / `XE_2D_U32x8x16_LD_N`
+  (`U16` = bf16/fp16 operands, `U32` = fp32 accumulator store `XE_2D_U32x8x16_ST_N`). VNNI
+  pre-interleaves the K dimension into the layout the systolic array consumes. These are built
+  via `get_block_2d_copy_A/B/C/D(mma, tensor)` (`gemm.hpp:81-82, 162`).
+- **Software-pipelined K-loop**: `make_block_2d_prefetch` issues 2D prefetches `prefetch_dist=3`
+  tiles ahead, with `barrier_arrive(scope)` / `barrier_wait(scope)` double-buffering around
+  `copy → reorder → cute::gemm` (`gemm.hpp:97-136`). `reorder(tArA, tCrA)` shuffles the loaded
+  fragment into the atom's expected lane layout before the MAD.
+- **int4 experts** go through a specialized caller `XE_GEMM_4BITS_CALLER(GroupSize)` for
+  group sizes 32/64/128/256 (`grouped_gemm_xe2.hpp:178-196`) — same DPAS atom, with an
+  in-fragment dequant of the 4-bit B operand against `ptr_scales`.
+- **Arch gating**: some MMA shapes are taken only on Battlemage (`if (vllm::xpu::is_bmg())`
+  selects the 16³ inverse MMA, `chunk_gated_delta_rule_kernels_xe2.hpp:1348`).
+
+**Why it matters for Arcaine**: if you want the same DPAS throughput you have two options —
+(a) depend on CUTLASS-SYCL `cute` and reuse these `XE_DPAS_TT` atoms + tile policies verbatim
+(what this repo does), or (b) write the matmuls against the SYCL
+`sycl::ext::oneapi::experimental::matrix::joint_matrix` API yourself
+(`joint_matrix_load` with VNNI layout → `joint_matrix_mad` → `joint_matrix_store`), which
+targets the identical DPAS instruction but is lower-level and you re-implement the tiling /
+prefetch pipeline by hand. The repo deliberately chose (a); the `WGTile`/`SGLayout` policies in
+§3.3 are the tuned configuration you'd otherwise have to rediscover. Note oneDNN (option in
+§7) hides DPAS entirely behind its matmul primitive — for plain projections that's the least
+work.
+
+---
+
+## 9. Reuse guidance for Arcaine
+
+Priority order for a Qwen3.5 bring-up, given Arcaine = SYCL + oneDNN + Battlemage (Xe2):
+
+1. **Lift `csrc/xpu/onednn/` almost verbatim.** It's already SYCL+oneDNN and gives w8a8/w8a16/
+   w4a16/w4a8/fp4 GEMM + a primitive cache — covers every Qwen3.5 linear projection and the MoE
+   experts (int4/mxfp4). Smallest effort, highest coverage.
+2. **Port the GDN native path first** (`gated_delta_rule.hpp` + `causal_conv1d.hpp`) for a
+   correct, un-tuned linear-attention baseline; validate against the transformers fallback
+   kernels at `chunk_size=64`.
+3. **Then adopt the XE2 chunked GDN** (`chunk_causal_conv1d_tiled_xe2.hpp` +
+   `chunk_gated_delta_rule_kernels_xe2.hpp` + `gemm.hpp`) for prefill throughput — this is the
+   single biggest perf lever and the hardest to get right (the four-GEMM chunk decomposition and
+   the fused l2norm). The `cute` tile policies (§3.3) are a ready-made starting config.
+4. **FMHA**: reuse `attn/xe_2` chunk-prefill + paged-decode for the 1-in-4 full-attention
+   layers; you only need the `(head=256, causal=true)` variant (no local/sink) for Qwen3.5.
+5. **MoE routing + grouped GEMM**: `csrc/moe/*` + `grouped_gemm/xe_2` give the full
+   route→GEMM→unroute pipeline with quantized experts; map the router to the softmax+renorm
+   `topk.cpp` path.
+6. **RoPE/norm**: `fused_qknorm_rope.cpp` (full-attn preamble) and `multimodal_rope.cpp`
+   (M-RoPE `[11,11,10]`) drop in directly.
+
+Caveats:
+- These are **inference-only** (no backward) — same limitation as the architecture doc.
+- **Spec-decode** paths (`spec_*` tensors) are vLLM-specific; skip for Arcaine v1.
+- The kernels assume vLLM's **paged KV + cu_seqlens varlen packing** and ragged index tensors;
+  Arcaine must produce the same `query_start_loc` / `state_indices` / `block_table` layouts or
+  adapt the launchers.
+- Licensing: kernel headers are **BSD-3-Clause** (Intel) (e.g.
+  `chunk_gated_delta_rule_kernels_xe2.hpp:1-31`); the repo top-level is Apache-2.0. Check
+  per-file headers before vendoring.
+
+---
+
+**Document version**: 1.0
+**Reference**: `vllm-project/vllm-xpu-kernels@main`, `csrc/xpu/{gdn_attn,attn,grouped_gemm,onednn,sycl}`, `csrc/moe`, `csrc/fused_qknorm_rope.cpp`
+**Companion**: `QWEN3_5_ARCHITECTURE.md`


### PR DESCRIPTION
Adds two companion analysis docs under `notes/qwen3_5/` to seed an Arcaine SYCL + oneDNN port of Qwen3.5. Architecture/kernel description only — no SYCL prescriptions beyond reuse guidance.

## 1. `QWEN3_5_ARCHITECTURE.md` — PyTorch reference (latest `transformers` 5.12.1)

- **No separate `qwen3_6` module.** Dense/MoE text towers are `qwen3_5` / `qwen3_5_moe`. Qwen3.5 ≈ **Qwen3-Next text tower × Qwen3-VL multimodal shell, minus DeepStack**.
- Hybrid token mixer on a fixed **3 linear : 1 full** schedule: `linear_attention` = **Gated DeltaNet** (gated delta rule) fronted by a **depthwise causal Conv1d**; `full_attention` = GQA softmax with QK-norm, partial RoPE, output gate.
- The **"conv1d op library"** = `causal_conv1d` (Dao-AILab) + **FLA**; readable PyTorch fallbacks are the executable spec.
- Covers configs, M-RoPE, **forward** and **backward** as separate sections, tensor shapes, hybrid cache layout, weight manifest, CUDA fast-path optimizations. All claims cited to `transformers` source.

## 2. `QWEN3_5_XPU_KERNELS.md` — Intel-GPU SYCL prior art (`vllm-project/vllm-xpu-kernels`)

Maps each Qwen3.5 component to an **existing SYCL/Xe kernel** (the most directly relevant prior art: SYCL + **oneDNN**, targets **Battlemage**, CUTLASS-SYCL `cute` + DPAS):

- **GatedDeltaNet**: `gdn_attn/` — tiled/untiled causal_conv1d with SLM staging + fused l2norm; chunked gated delta rule (`chunk_size=64`) as four DPAS GEMMs; decode/prefill/spec split.
- **Full attention**: `attn/xe_2/` paged-KV FMHA (chunk-prefill + paged-decode), varlen, local/sink/lse compile-time variants.
- **Fused QK-norm+RoPE** and **interleaved M-RoPE** kernels.
- **MoE**: cutlass grouped GEMM with int4/mxfp4 experts + routing/scatter kernels.
- **oneDNN matmul** (fp8/fp4/int4) — directly liftable into Arcaine's oneDNN stack.
- **Matrix engine**: documents that these kernels use `cute` `XE_DPAS_TT` atoms — **not** the raw SYCL `joint_matrix` API — and how the DPAS tiling / VNNI 2D-loads / prefetch pipeline works.
- Component→kernel map, Battlemage arch gating, prioritized reuse guidance, per-file licensing (BSD-3-Clause Intel headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)