### PR TITLE
diffusion_gemma: decode-throughput experiments (soft_next modes, GPU router top-k, MoE tail-cap)

### DIFF
--- a/.maki/permissions.toml
+++ b/.maki/permissions.toml
@@ -1,0 +1,8 @@
+[bash]
+allow = [
+    "cd *",
+    "python3 *",
+    "timeout *",
+    "tail *",
+    "echo *",
+]

--- a/.maki/permissions.toml
+++ b/.maki/permissions.toml
@@ -5,4 +5,6 @@ allow = [
     "timeout *",
     "tail *",
     "echo *",
+    "ls *",
+    "head *",
 ]

--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ It's early days and the project is expected to move quickly- there are a ton of 
 
 ## Performance
 
-Arcaine currently implements DiffusionGemma
+For NVFP4 the current best performing set of env args is
 
+```
+DIFF_ROUTER_GPU_TOPK=on DIFF_SKIP_LAST_SOFT_NEXT=1 DIFF_PERSIST_XFER_STAGE=1 DIFF_SOFT_NEXT=topk:8 DIFF_ONEDNN_SDPA=decode
+```
+These are cobbled together but define the codepath taken at inference time; Arcaine currently contains many A/B style knobs for controlling behavior- so far this has been difficult to scale/maintain, so I expect changes.
 
 ## Supported Models
 
@@ -68,6 +72,8 @@ cmake -B build -G Ninja \
   -DARCAINE_SYCL_TARGETS=intel_gpu_bmg_g31
 cmake --build build -j"$(nproc)"
 ```
+
+
 
 Doing the build makes a few binaries which all accept `--help`.
 

--- a/bench/sweep/plot.py
+++ b/bench/sweep/plot.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Read the sweep SQLite DB and emit comparison PNGs (needs matplotlib).
+
+Run:
+    python3 bench/sweep/plot.py --db bench/sweep/results.db --out bench/sweep/plots
+"""
+import argparse
+import math
+import os
+import sqlite3
+import sys
+
+# matplotlib is imported lazily (_ensure_mpl) so that --help and the pure
+# helpers work without matplotlib installed (it is installed one-time inside
+# the container, per the plan).
+plt = None
+
+
+def _ensure_mpl():
+    global plt
+    if plt is None:
+        import matplotlib
+        matplotlib.use("Agg")  # headless
+        import matplotlib.pyplot as _plt
+        plt = _plt
+
+
+SWEEP_DIR = os.path.dirname(os.path.abspath(__file__))
+
+GPUS = ["single", "dual"]
+KERNELS = ["default", "hybrid", "custom"]
+S1S = ["off", "decode_kv", "stage_kv", "onednn_sdpa", "all"]
+SOFT_NEXTS = ["exact", "hard", "topk"]
+FORCES = ["off", "on"]
+
+SHORT = {
+    "sampler": "sampler", "soft_next": "soft_next", "s1": "s1",
+    "force_denoise": "force", "skip_last_soft_next": "skip",
+    "kernel": "kernel", "grouped_gemm": "gg", "gpu_layout": "gl",
+}
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def mean_sd(vals):
+    n = len(vals)
+    if n == 0:
+        return None, 0.0
+    m = sum(vals) / n
+    if n == 1:
+        return m, 0.0
+    var = sum((x - m) ** 2 for x in vals) / (n - 1)  # sample stddev
+    return m, math.sqrt(var)
+
+
+def where(filters):
+    parts, params = [], []
+    for k, v in filters.items():
+        if v is None:
+            parts.append(f"{k} IS NULL")
+        else:
+            parts.append(f"{k} = ?")
+            params.append(v)
+    return " AND ".join(parts), params
+
+
+def note_str(filters, skip=("sweep_group",)):
+    return " ".join(
+        f"{SHORT.get(k, k)}={v}" for k, v in filters.items() if k not in skip
+    )
+
+
+def git_sha(cur):
+    cur.execute("SELECT git_sha FROM runs ORDER BY id DESC LIMIT 1")
+    row = cur.fetchone()
+    return row[0] if row and row[0] else "unknown"
+
+
+def grouped_bar(ax, series, vary_vals, data, ylabel, plt):
+    """data: {(series_val, vary_val): (mean, sd)}; bars grouped by vary_val."""
+    n = len(series)
+    width = 0.8 / max(n, 1)
+    x = list(range(len(vary_vals)))
+    for si, s in enumerate(series):
+        means = [data.get((s, v), (float("nan"), 0.0))[0] for v in vary_vals]
+        sds = [data.get((s, v), (float("nan"), 0.0))[1] for v in vary_vals]
+        offs = [xi + (si - (n - 1) / 2) * width for xi in x]
+        ax.bar(offs, means, width=width, yerr=sds, label=s, capsize=3)
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(v) for v in vary_vals])
+    ax.set_ylabel(ylabel)
+    ax.legend(title="gpu")
+    ax.grid(axis="y", alpha=0.3)
+
+
+# ---------------------------------------------------------------------------
+# plots
+# ---------------------------------------------------------------------------
+
+def bar_plot(cur, outdir, fname, title, filters, vary_col, vary_vals, ylabel,
+             sha, series=GPUS):
+    where_sql, params = where(filters)
+    sql = f"SELECT gpu, {vary_col}, output_tps FROM runs WHERE {where_sql}"
+    cur.execute(sql, params)
+    agg = {}
+    for gpu, vval, out in cur.fetchall():
+        agg.setdefault((gpu, vval), []).append(out)
+    _ensure_mpl()
+    data = {}
+    for gpu in series:
+        for vval in vary_vals:
+            vals = agg.get((gpu, vval))
+            if vals:
+                m, sd = mean_sd(vals)
+                data[(gpu, vval)] = (m, sd)
+    fig, ax = plt.subplots(figsize=(7, 5))
+    grouped_bar(ax, series, vary_vals, data, ylabel, plt)
+    ax.set_title(f"{title}\ngit {sha}  | fixed: {note_str(filters)}", fontsize=10)
+    fig.tight_layout()
+    path = os.path.join(outdir, fname)
+    fig.savefig(path, dpi=130)
+    plt.close(fig)
+    return path, len(data)
+
+
+def plot_sampler(cur, outdir, sha):
+    filters = {"sweep_group": "decode", "s1": "all", "soft_next": "exact",
+               "force_denoise": "off", "skip_last_soft_next": "off",
+               "kernel": "hybrid", "grouped_gemm": None, "gpu_layout": None}
+    return bar_plot(cur, outdir, "sampler.png", "output t/s: device vs host sampler",
+                    filters, "sampler", ["device", "host"], "output t/s", sha)
+
+
+def plot_s1(cur, outdir, sha):
+    filters = {"sweep_group": "decode", "sampler": "device", "soft_next": "exact",
+               "force_denoise": "off", "skip_last_soft_next": "off",
+               "kernel": "hybrid", "grouped_gemm": None, "gpu_layout": None}
+    return bar_plot(cur, outdir, "s1_fusions.png", "output t/s: S1 fusion variants",
+                    filters, "s1", S1S, "output t/s", sha)
+
+
+def plot_soft_next(cur, outdir, sha):
+    filters = {"sweep_group": "decode", "sampler": "device", "s1": "all",
+               "force_denoise": "off", "skip_last_soft_next": "off",
+               "kernel": "hybrid", "grouped_gemm": None, "gpu_layout": None}
+    return bar_plot(cur, outdir, "soft_next.png",
+                    "output t/s: soft_next modes", filters,
+                    "soft_next", SOFT_NEXTS, "output t/s", sha)
+
+
+def plot_force_denoise(cur, outdir, sha):
+    filters = {"sweep_group": "decode", "sampler": "device", "s1": "all",
+               "soft_next": "exact", "skip_last_soft_next": "off",
+               "kernel": "hybrid", "grouped_gemm": None, "gpu_layout": None}
+    return bar_plot(cur, outdir, "force_denoise.png",
+                    "output t/s: force_denoise (stop-flag D2H cost)",
+                    filters, "force_denoise", FORCES, "output t/s", sha)
+
+
+def plot_nvfp4_kernels(cur, outdir, sha):
+    # focus decode config from the decode group; grouped_gemm/gpu_layout NULL.
+    filters = {"sweep_group": "decode", "sampler": "device", "s1": "all",
+               "soft_next": "hard", "force_denoise": "on",
+               "skip_last_soft_next": "on", "grouped_gemm": None,
+               "gpu_layout": None}
+    return bar_plot(cur, outdir, "nvfp4_kernels.png",
+                    "output t/s: NVFP4 expert kernels", filters,
+                    "kernel", KERNELS, "output t/s", sha)
+
+
+def plot_nvfp4_micro(cur, outdir, sha):
+    """grouped_gemm x gpu_layout heatmap per GPU; aggregate over kernel+run_idx."""
+    filters = {"sweep_group": "nvfp4"}  # decode axes are fixed in this group
+    where_sql, params = where(filters)
+    sql = ("SELECT gpu, grouped_gemm, gpu_layout, output_tps FROM runs "
+           f"WHERE {where_sql}")
+    cur.execute(sql, params)
+    agg = {}
+    for gpu, gg, gl, out in cur.fetchall():
+        agg.setdefault((gpu, gg, gl), []).append(out)
+    _ensure_mpl()
+    gg_vals = ["off", "xe2"]
+    gl_vals = ["off", "on"]
+    fig, axes = plt.subplots(1, len(GPUS), figsize=(10, 4.5), squeeze=False)
+    n_cells = 0
+    for ai, gpu in enumerate(GPUS):
+        ax = axes[0][ai]
+        mat = []
+        for gg in gg_vals:
+            row = []
+            for gl in gl_vals:
+                vals = agg.get((gpu, gg, gl))
+                if vals:
+                    m, _ = mean_sd(vals)
+                    n_cells += 1
+                else:
+                    m = float("nan")
+                row.append(m)
+            mat.append(row)
+        ax.imshow(mat, aspect="auto", cmap="viridis")
+        ax.set_xticks(range(len(gl_vals))); ax.set_xticklabels(gl_vals)
+        ax.set_yticks(range(len(gg_vals))); ax.set_yticklabels(gg_vals)
+        ax.set_xlabel("gpu_layout")
+        ax.set_ylabel("grouped_gemm")
+        ax.set_title(f"gpu={gpu}")
+        for i in range(len(gg_vals)):
+            for j in range(len(gl_vals)):
+                v = mat[i][j]
+                ax.text(j, i, f"{v:.1f}" if v == v else "n/a",
+                        ha="center", va="center",
+                        color="white" if v == v and v < 50 else "black")
+    fig.suptitle(f"NVFP4 micro: output t/s (mean over kernels)\n"
+                 f"git {sha}  | fixed: sampler=device s1=all soft_next=hard "
+                 f"force=on skip=on", fontsize=10)
+    fig.tight_layout()
+    path = os.path.join(outdir, "nvfp4_micro.png")
+    fig.savefig(path, dpi=130)
+    plt.close(fig)
+    return path, n_cells
+
+
+def plot_summary_table(cur, outdir, sha):
+    """Top-10 configs by mean output t/s overall."""
+    # A "config" = gpu + all axis columns + kernel (workload fixed: p/n/ds).
+    cols = ["gpu", "sampler", "soft_next", "s1", "force_denoise",
+            "skip_last_soft_next", "grouped_gemm", "gpu_layout", "kernel"]
+    sel = ", ".join(cols)
+    cur.execute(f"SELECT {sel}, output_tps FROM runs")
+    agg = {}
+    for row in cur.fetchall():
+        out = row[-1]
+        key = row[:-1]
+        agg.setdefault(key, []).append(out)
+    rows = []
+    for key, vals in agg.items():
+        m, _ = mean_sd(vals)
+        if m is not None:
+            rows.append((m, key, len(vals)))
+    rows.sort(key=lambda r: r[0], reverse=True)
+    top = rows[:10]
+
+    _ensure_mpl()
+    fig, ax = plt.subplots(figsize=(13, 5))
+    ax.axis("off")
+    header = ["rank", "output t/s", "n"] + [SHORT.get(c, c) for c in cols]
+    table = [header]
+    for i, (m, key, n) in enumerate(top, 1):
+        table.append([str(i), f"{m:.1f}", str(n)] + [str(k) for k in key])
+    tbl = ax.table(cellText=table[1:], colLabels=table[0], loc="center",
+                  cellLoc="center")
+    tbl.auto_set_font_size(False)
+    tbl.set_fontsize(8)
+    tbl.scale(1.0, 1.4)
+    ax.set_title(f"Top-10 configs by output t/s (overall)\ngit {sha}",
+                 fontsize=11)
+    fig.tight_layout()
+    path = os.path.join(outdir, "summary_table.png")
+    fig.savefig(path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    return path, len(top)
+
+
+PLOTS = [
+    ("sampler.png", plot_sampler),
+    ("s1_fusions.png", plot_s1),
+    ("soft_next.png", plot_soft_next),
+    ("force_denoise.png", plot_force_denoise),
+    ("nvfp4_kernels.png", plot_nvfp4_kernels),
+    ("nvfp4_micro.png", plot_nvfp4_micro),
+    ("summary_table.png", plot_summary_table),
+]
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Plot sweep results to PNGs.")
+    p.add_argument("--db", default=os.path.join(SWEEP_DIR, "results.db"))
+    p.add_argument("--out", default=os.path.join(SWEEP_DIR, "plots"))
+    args = p.parse_args(argv)
+
+    if not os.path.isfile(args.db):
+        print(f"db not found: {args.db}", file=sys.stderr)
+        return 1
+    os.makedirs(args.out, exist_ok=True)
+
+    conn = sqlite3.connect(args.db)
+    cur = conn.cursor()
+    sha = git_sha(cur)
+
+    cur.execute("SELECT COUNT(*) FROM runs")
+    total = cur.fetchone()[0]
+    print(f"# db={args.db} rows={total} git={sha} -> {args.out}")
+
+    for fname, fn in PLOTS:
+        try:
+            path, n = fn(cur, args.out, sha)
+            print(f"  wrote {path} ({n} cells)")
+        except Exception as e:  # one missing dataset must not kill the rest
+            print(f"  SKIP {fname}: {e}", file=sys.stderr)
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/sweep/requirements.txt
+++ b/bench/sweep/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib

--- a/bench/sweep/sweep.py
+++ b/bench/sweep/sweep.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""Decode-path + NVFP4 benchmark sweep harness.
+
+Stdlib-only. Invokes the already-built ``diffusion_bench`` binary with different
+env vars / args, parses per-run ``[bench]`` lines into a SQLite DB. Resumable.
+
+The harness changes no C++; it only drives the binary. See the plan
+(super-valued-moccasin.md) and memory note ``diffusion_bench_harness.md`` for the
+verified CLI/output contract.
+"""
+import argparse
+import collections
+import datetime
+import itertools
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+
+# Directory this script lives in (bench/sweep/). DB + logs default to here so the
+# harness is cwd-independent.
+SWEEP_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# ---------------------------------------------------------------------------
+# Axis -> env mapping (see plan: "Axis -> env-var mapping").
+#   - "device" sampler and "exact" soft_next mean the env var is UNSET, so the
+#     harness explicitly drops every DIFF_* knob from the inherited env before
+#     adding the axis-specific ones (see compose_env).
+# ---------------------------------------------------------------------------
+
+# All env vars the harness manages. These are stripped from the inherited env so
+# that "unset" really means unset (no leakage from the parent shell).
+MANAGED_ENV = [
+    "DIFF_HOST_SAMPLER",
+    "DIFF_SOFT_NEXT",
+    "DIFF_DECODE_KV_DIRECT_CACHE",
+    "DIFF_STAGE_DECODER_KV_KERNEL",
+    "DIFF_ONEDNN_SDPA",
+    "DIFF_FORCE_DENOISE_STEPS",
+    "DIFF_SKIP_LAST_SOFT_NEXT",
+    "DIFF_NVFP4_GROUPED_GEMM",
+    "DIFF_NVFP4_GPU_LAYOUT",
+    "DIFF_NVFP4_GPU_LAYOUT_MAX_SEQ",
+    "ZE_AFFINITY_MASK",
+]
+
+KERN_DEFAULT = "default,hybrid,custom"
+
+
+def env_gpu(v):
+    return {"ZE_AFFINITY_MASK": "0" if v == "single" else "0,1"}
+
+
+def env_sampler(v):
+    return {} if v == "device" else {"DIFF_HOST_SAMPLER": "1"}
+
+
+def env_soft_next(v):
+    return {} if v == "exact" else {"DIFF_SOFT_NEXT": v}  # hard | topk:8
+
+
+def env_s1(v):
+    out = {}
+    if v == "off":
+        return out
+    if v in ("decode_kv", "all"):
+        out["DIFF_DECODE_KV_DIRECT_CACHE"] = "1"
+    if v in ("stage_kv", "all"):
+        out["DIFF_STAGE_DECODER_KV_KERNEL"] = "1"
+    if v in ("onednn_sdpa", "all"):
+        out["DIFF_ONEDNN_SDPA"] = "decode"
+    return out
+
+
+def env_force_denoise(v):
+    return {} if v == "off" else {"DIFF_FORCE_DENOISE_STEPS": "1"}
+
+
+def env_skip_last(v):
+    return {} if v == "off" else {"DIFF_SKIP_LAST_SOFT_NEXT": "1"}
+
+
+def env_grouped_gemm(v):
+    # None (decode group, not an axis) and "off" both leave the knob unset.
+    return {} if v in (None, "off") else {"DIFF_NVFP4_GROUPED_GEMM": "xe2"}
+
+
+def env_gpu_layout(v):
+    # gpu_layout=on also raises the decode-seq gate so the path actually engages
+    # (canvas seq 256 > default gate 64). None (decode group) -> unset.
+    if v in (None, "off"):
+        return {}
+    return {
+        "DIFF_NVFP4_GPU_LAYOUT": "1",
+        "DIFF_NVFP4_GPU_LAYOUT_MAX_SEQ": "512",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Launch plan
+# ---------------------------------------------------------------------------
+
+def _decode_axes(gpu, sampler, soft_next, s1, force, skip):
+    return {
+        "sweep_group": "decode",
+        "gpu": gpu,
+        "sampler": sampler,
+        "soft_next": soft_next,
+        "s1": s1,
+        "force_denoise": force,
+        "skip_last_soft_next": skip,
+        "grouped_gemm": None,   # not an axis in this group
+        "gpu_layout": None,
+    }
+
+
+def _nvfp4_axes(gpu, grouped_gemm, gpu_layout):
+    return {
+        "sweep_group": "nvfp4",
+        "gpu": gpu,
+        # Fixed "expected-best" decode config (plan, Group 2).
+        "sampler": "device",
+        "soft_next": "hard",
+        "s1": "all",
+        "force_denoise": "on",
+        "skip_last_soft_next": "on",
+        "grouped_gemm": grouped_gemm,
+        "gpu_layout": gpu_layout,
+    }
+
+
+def _env_from_axes(axes):
+    env = {}
+    env.update(env_gpu(axes["gpu"]))
+    env.update(env_sampler(axes["sampler"]))
+    env.update(env_soft_next(axes["soft_next"]))
+    env.update(env_s1(axes["s1"]))
+    env.update(env_force_denoise(axes["force_denoise"]))
+    env.update(env_skip_last(axes["skip_last_soft_next"]))
+    env.update(env_grouped_gemm(axes["grouped_gemm"]))
+    env.update(env_gpu_layout(axes["gpu_layout"]))
+    return env
+
+
+def build_plan(groups):
+    """Return list of cells: {"axes": {...}, "env": {...}, "kernels": "..."}."""
+    plan = []
+    if "decode" in groups:
+        for gpu, sampler, soft_next, s1, force, skip in itertools.product(
+            ["single", "dual"],
+            ["device", "host"],
+            ["exact", "hard", "topk"],
+            ["off", "decode_kv", "stage_kv", "onednn_sdpa", "all"],
+            ["off", "on"],
+            ["off", "on"],
+        ):
+            axes = _decode_axes(gpu, sampler, soft_next, s1, force, skip)
+            plan.append({"axes": axes, "env": _env_from_axes(axes),
+                         "kernels": KERN_DEFAULT})
+    if "nvfp4" in groups:
+        for gpu, gg, gl in itertools.product(
+            ["single", "dual"], ["off", "xe2"], ["off", "on"]
+        ):
+            axes = _nvfp4_axes(gpu, gg, gl)
+            plan.append({"axes": axes, "env": _env_from_axes(axes),
+                         "kernels": KERN_DEFAULT})
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# SQLite
+# ---------------------------------------------------------------------------
+
+COLS = [
+    "ts", "git_sha", "sweep_group", "gpu", "sampler", "soft_next", "s1",
+    "force_denoise", "skip_last_soft_next", "grouped_gemm", "gpu_layout",
+    "kernel", "n_prompt", "n_gen", "ds", "run_idx",
+    "prefill_tps", "output_tps", "canvas_pos_s", "fwd_s", "passes",
+    "kv_mb_per_tok", "arena_gb", "tok_per_fwd",
+]
+
+# Columns that uniquely identify a cell's expected output (exclude kernel + run_idx,
+# which are swept in-process / per-timed-run). Used for resumability.
+KEY_COLS = [
+    "sweep_group", "gpu", "sampler", "soft_next", "s1", "force_denoise",
+    "skip_last_soft_next", "grouped_gemm", "gpu_layout", "n_prompt", "n_gen", "ds",
+]
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+  id            INTEGER PRIMARY KEY,
+  ts            TEXT,
+  git_sha       TEXT,
+  sweep_group   TEXT,
+  gpu           TEXT,
+  sampler       TEXT,
+  soft_next     TEXT,
+  s1            TEXT,
+  force_denoise TEXT,
+  skip_last_soft_next TEXT,
+  grouped_gemm  TEXT,
+  gpu_layout    TEXT,
+  kernel        TEXT,
+  n_prompt      INTEGER,
+  n_gen         INTEGER,
+  ds            INTEGER,
+  run_idx       INTEGER,
+  prefill_tps   REAL,
+  output_tps    REAL,
+  canvas_pos_s  REAL,
+  fwd_s         REAL,
+  passes        INTEGER,
+  kv_mb_per_tok REAL,
+  arena_gb      REAL,
+  tok_per_fwd   REAL
+);
+CREATE INDEX IF NOT EXISTS idx_combo ON runs(
+  gpu, sampler, soft_next, s1, force_denoise, skip_last_soft_next,
+  grouped_gemm, gpu_layout, kernel
+);
+"""
+
+
+def open_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA)
+    conn.commit()
+    return conn
+
+
+def cell_key(cell, args):
+    a = cell["axes"]
+    return {
+        "sweep_group": a["sweep_group"],
+        "gpu": a["gpu"],
+        "sampler": a["sampler"],
+        "soft_next": a["soft_next"],
+        "s1": a["s1"],
+        "force_denoise": a["force_denoise"],
+        "skip_last_soft_next": a["skip_last_soft_next"],
+        "grouped_gemm": a["grouped_gemm"],
+        "gpu_layout": a["gpu_layout"],
+        "n_prompt": args.p,
+        "n_gen": args.n,
+        "ds": args.ds,
+    }
+
+
+def _where(key):
+    # IS handles NULL grouped_gemm/gpu_layout for the decode group.
+    return " AND ".join(f"{c} IS ?" for c in key)
+
+
+def cell_count(cur, key):
+    cur.execute(f"SELECT COUNT(*) FROM runs WHERE {_where(key)}",
+                tuple(key.values()))
+    return cur.fetchone()[0]
+
+
+def delete_cell(cur, key):
+    cur.execute(f"DELETE FROM runs WHERE {_where(key)}", tuple(key.values()))
+
+
+def insert_row(cur, row):
+    cur.execute(
+        "INSERT INTO runs (" + ",".join(COLS) + ") VALUES (" +
+        ",".join("?" * len(COLS)) + ")",
+        tuple(row.get(c) for c in COLS),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+# Matches diffusion_bench.cpp:292-298 (one line per timed run):
+#   [bench] <kernel> p<N> n<N> run i/R: prefill X t/s | output Y t/s |
+#   canvas Z pos/s | W fwd/s | P passes | kv K MB/token | arena A GB
+BENCH_RE = re.compile(
+    r"\[bench\]\s+(\S+)\s+p(\d+)\s+n(\d+)\s+run\s+(\d+)/(\d+):\s+"
+    r"prefill\s+([-+0-9.]+)\s+t/s\s+\|\s+"
+    r"output\s+([-+0-9.]+)\s+t/s\s+\|\s+"
+    r"canvas\s+([-+0-9.]+)\s+pos/s\s+\|\s+"
+    r"([-+0-9.]+)\s+fwd/s\s+\|\s+"
+    r"(\d+)\s+passes\s+\|\s+"
+    r"kv\s+([-+0-9.]+)\s+MB/token\s+\|\s+"
+    r"arena\s+([-+0-9.]+)\s+GB"
+)
+
+
+def parse_bench_line(line):
+    m = BENCH_RE.search(line)
+    if not m:
+        return None
+    (kernel, p, n, run_i, run_r, prefill, output, canvas,
+     fwd, passes, kv, arena) = m.groups()
+    fwd_f = float(fwd)
+    return {
+        "kernel": kernel,
+        "n_prompt": int(p),
+        "n_gen": int(n),
+        "run_idx": int(run_i),
+        "prefill_tps": float(prefill),
+        "output_tps": float(output),
+        "canvas_pos_s": float(canvas),
+        "fwd_s": fwd_f,
+        "passes": int(passes),
+        "kv_mb_per_tok": float(kv),
+        "arena_gb": float(arena),
+        "tok_per_fwd": (float(output) / fwd_f) if fwd_f else 0.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def now_iso():
+    return datetime.datetime.now().isoformat(timespec="seconds")
+
+
+def combo_str(cell):
+    a = cell["axes"]
+    parts = ["grp=" + a["sweep_group"], "gpu=" + a["gpu"]]
+    for c in ("sampler", "soft_next", "s1", "force_denoise",
+              "skip_last_soft_next", "grouped_gemm", "gpu_layout"):
+        parts.append(c + "=" + str(a[c]))
+    return ",".join(parts)
+
+
+def compose_env(axis_env):
+    """Inherit the parent env (PATH/ONEAPI/LD_LIBRARY_PATH/...) but drop every
+    knob the harness manages, then add the axis-specific ones."""
+    env = dict(os.environ)
+    for v in MANAGED_ENV:
+        env.pop(v, None)
+    env.update(axis_env)
+    return env
+
+
+def fmt_eta(secs):
+    if secs is None or secs < 0 or secs != secs:  # nan check
+        return "?"
+    secs = int(secs)
+    h, rem = divmod(secs, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h{m:02d}m"
+    return f"{m}m{s:02d}s"
+
+
+def git_sha(repo_dir):
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo_dir, "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Run one process (one cell)
+# ---------------------------------------------------------------------------
+
+def run_cell(conn, cur, args, git_sha_val, cell, key, logf, failf, verbose):
+    """Launch one process, parse + insert rows. Returns (n_parsed, rc, elapsed)."""
+    env = compose_env(cell["env"])
+    cmd = [
+        args.binary, "--model", args.model,
+        "-p", str(args.p), "-n", str(args.n), "-ds", str(args.ds),
+        "-w", str(args.warmup), "-r", str(args.runs),
+        "--kernels", cell["kernels"],
+    ]
+    t0 = time.monotonic()
+    recent = collections.deque(maxlen=60)  # for failure diagnostics
+    parsed = 0
+    try:
+        proc = subprocess.Popen(
+            cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1,
+        )
+    except FileNotFoundError:
+        msg = f"[sweep] binary not found: {args.binary}"
+        print(msg, file=sys.stderr)
+        failf.write(f"--- {now_iso()} {combo_str(cell)} BINARY-MISSING\n")
+        failf.flush()
+        return 0, 127, time.monotonic() - t0
+
+    with proc:
+        for line in proc.stdout:
+            recent.append(line.rstrip())
+            if verbose:
+                sys.stdout.write(line); sys.stdout.flush()
+            rec = parse_bench_line(line)
+            if rec is not None:
+                row = dict(key)  # the axis/workload identifying columns
+                row["ts"] = now_iso()
+                row["git_sha"] = git_sha_val
+                row["kernel"] = rec["kernel"]
+                row["run_idx"] = rec["run_idx"]
+                row["n_prompt"] = rec["n_prompt"]
+                row["n_gen"] = rec["n_gen"]
+                row["ds"] = args.ds
+                for c in ("prefill_tps", "output_tps", "canvas_pos_s", "fwd_s",
+                          "passes", "kv_mb_per_tok", "arena_gb", "tok_per_fwd"):
+                    row[c] = rec[c]
+                insert_row(cur, row)
+                conn.commit()
+                parsed += 1
+        rc = proc.wait()
+    elapsed = time.monotonic() - t0
+
+    if rc != 0 or parsed == 0:
+        failf.write(f"--- {now_iso()} {combo_str(cell)} rc={rc} parsed={parsed}\n")
+        for ln in recent:
+            failf.write("    " + ln + "\n")
+        failf.flush()
+    return parsed, rc, elapsed
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def list_models():
+    """--list-models: os.listdir('/workspace/models') (container path), with a
+    graceful fallback to ./models so the flag also works on the host."""
+    for cand in ("/workspace/models", os.path.join(SWEEP_DIR, "..", "..", "models")):
+        if os.path.isdir(cand):
+            entries = sorted(os.listdir(cand))
+            print(f"# {cand} ({len(entries)} entries)")
+            for e in entries:
+                print(e)
+            return 0
+    print("no /workspace/models and no ./models directory found", file=sys.stderr)
+    return 1
+
+
+def dry_run(plan, args):
+    print(f"# sweep plan: {len(plan)} process launches")
+    cells = len(plan) * 3  # 3 kernels in-process
+    runs = cells * args.runs
+    print(f"# cells={cells} timed_runs={runs} (kernels in-process, runs={args.runs})")
+    print("# group      gpu    sampler soft_next s1         force skip  grouped_gemm gpu_layout kernels")
+    for cell in plan:
+        a = cell["axes"]
+        print(f"  {a['sweep_group']:10s} {a['gpu']:6s} {a['sampler']:7s} "
+              f"{a['soft_next']:9s} {a['s1']:10s} {a['force_denoise']:5s} "
+              f"{a['skip_last_soft_next']:4s} {str(a['grouped_gemm']):11s} "
+              f"{str(a['gpu_layout']):10s} {cell['kernels']}")
+    return 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description="Decode-path + NVFP4 benchmark sweep harness.",
+    )
+    p.add_argument("--model", help="model directory (required unless --list-models)")
+    p.add_argument("--binary", default="build/diffusion_bench",
+                   help="path to diffusion_bench (default: build/diffusion_bench)")
+    p.add_argument("--p", type=int, default=512, help="prompt tokens (default 512)")
+    p.add_argument("--n", type=int, default=128, help="generated tokens (default 128)")
+    p.add_argument("--ds", type=int, default=48, help="denoising steps (default 48)")
+    p.add_argument("--warmup", "-w", type=int, default=2, help="warmup runs (default 2)")
+    p.add_argument("--runs", "-r", type=int, default=3, help="timed runs (default 3)")
+    p.add_argument("--groups", default="decode,nvfp4",
+                   help="comma list of decode,nvfp4 (default: decode,nvfp4)")
+    p.add_argument("--db", default=os.path.join(SWEEP_DIR, "results.db"),
+                   help="SQLite DB path")
+    p.add_argument("--dry-run", action="store_true", help="print the plan and exit")
+    p.add_argument("--force", action="store_true",
+                   help="re-run completed cells (deletes existing rows first)")
+    p.add_argument("--list-models", action="store_true",
+                   help="list /workspace/models and exit")
+    p.add_argument("--verbose", action="store_true",
+                   help="tee binary stdout to console")
+    args = p.parse_args(argv)
+
+    if args.list_models:
+        return list_models()
+
+    groups = [g.strip() for g in args.groups.split(",") if g.strip()]
+    bad = [g for g in groups if g not in ("decode", "nvfp4")]
+    if bad:
+        p.error(f"unknown group(s): {bad} (valid: decode, nvfp4)")
+
+    if not args.model:
+        p.error("--model is required (or use --list-models)")
+
+    plan = build_plan(groups)
+
+    if args.dry_run:
+        return dry_run(plan, args)
+
+    if not os.path.isfile(args.binary):
+        p.error(f"binary not found: {args.binary} (build it first)")
+
+    conn = open_db(args.db)
+    cur = conn.cursor()
+    git_sha_val = git_sha(os.getcwd())
+    expected_per_cell = 3 * args.runs  # 3 kernels in-process x timed runs
+
+    log_path = os.path.join(SWEEP_DIR, "sweep.log")
+    fail_path = os.path.join(SWEEP_DIR, "sweep.failures.log")
+    logf = open(log_path, "a", buffering=1)
+    failf = open(fail_path, "a", buffering=1)
+
+    header = (f"[sweep] start {now_iso()} git={git_sha_val} "
+              f"model={args.model} p={args.p} n={args.n} ds={args.ds} "
+              f"w={args.warmup} r={args.runs} groups={','.join(groups)} "
+              f"plan={len(plan)} db={args.db}")
+    print(header, file=sys.stderr)
+    logf.write(header + "\n")
+
+    run_elapsed = []  # only actually-launched processes (for ETA)
+    N = len(plan)
+    skipped = 0
+    failed = 0
+    done_cells = 0
+    for i, cell in enumerate(plan, 1):
+        key = cell_key(cell, args)
+        count = cell_count(cur, key)
+        if args.force:
+            if count:
+                delete_cell(cur, key)
+                conn.commit()
+        elif count >= expected_per_cell:
+            skipped += 1
+            msg = (f"[sweep] {i}/{N} {combo_str(cell)} SKIP "
+                   f"(have {count}/{expected_per_cell})")
+            print(msg, file=sys.stderr)
+            continue
+        elif 0 < count < expected_per_cell:
+            # partial -> delete and re-run to avoid duplicates
+            delete_cell(cur, key)
+            conn.commit()
+
+        msg = f"[sweep] {i}/{N} {combo_str(cell)} running..."
+        print(msg, file=sys.stderr)
+
+        parsed, rc, elapsed = run_cell(
+            conn, cur, args, git_sha_val, cell, key, logf, failf, args.verbose,
+        )
+        run_elapsed.append(elapsed)
+        if parsed == 0 or rc != 0:
+            failed += 1
+        done_cells = i
+        mean = sum(run_elapsed) / len(run_elapsed) if run_elapsed else 0.0
+        eta = mean * (N - i)
+        msg = (f"[sweep] {i}/{N} {combo_str(cell)} parsed={parsed} rc={rc} "
+               f"elapsed={elapsed:.1f}s eta={fmt_eta(eta)} "
+               f"(skipped={skipped} failed={failed})")
+        print(msg, file=sys.stderr)
+        logf.write(msg + "\n")
+
+    summary = (f"[sweep] done {now_iso()} launched={done_cells - skipped}/{N} "
+               f"skipped={skipped} failed={failed} db={args.db}")
+    print(summary, file=sys.stderr)
+    logf.write(summary + "\n")
+    logf.close()
+    failf.close()
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/common/gpu/expert_parallel.cpp
+++ b/src/common/gpu/expert_parallel.cpp
@@ -99,6 +99,17 @@ static bool nvfp4_grouped_gemm_xe2_enabled() {
     return enabled;
 }
 
+// xe2v2: the rewritten per-expert DPAS kernel (arithmetic dequant, no k-split,
+// no global LUT). Distinct value so the old xe2 path is preserved for A/B.
+static bool nvfp4_grouped_gemm_xe2v2_enabled() {
+    static bool enabled = [] {
+        const char* env = std::getenv("DIFF_NVFP4_GROUPED_GEMM");
+        if (!env) return false;
+        return !std::strcmp(env, "xe2v2");
+    }();
+    return enabled;
+}
+
 static bool q8_use_hybrid_expert_kernel() {
     static bool enabled = [] {
         const char* env = std::getenv("DIFF_Q8_EXPERT_KERNEL");
@@ -341,7 +352,8 @@ static bool run_shard_nvfp4_gpu_layout(
 
     int HG = H / 16;
     int IG = moe_inter / 16;
-    bool use_xe2_gemm = nvfp4_grouped_gemm_xe2_enabled();
+    bool use_xe2v2 = nvfp4_grouped_gemm_xe2v2_enabled();
+    bool use_xe2_gemm = !use_xe2v2 && nvfp4_grouped_gemm_xe2_enabled();
     std::vector<const uint8_t*> gate_w(localE), gate_s(localE), down_w(localE), down_s(localE);
     std::vector<const float*> gate_dst(localE), down_dst(localE);
     std::vector<float> gate_input(localE), down_input(localE);
@@ -388,7 +400,12 @@ static bool run_shard_nvfp4_gpu_layout(
 
     auto gu = ar.alloc<bf16>((size_t)A_all * 2 * moe_inter);
     { DIFF_PROF(q, prof.gateup_mm);
-      if (use_xe2_gemm) {
+      if (use_xe2v2) {
+          matmul_nvfp4_grouped_rows_xe2_v2(ctx, xe_packed.data(), xe_scale.data(), H,
+                                           expert_offsets_dev.data(), rows_per_expert_dev.data(), localE,
+                                           gate_w_dev.data(), gate_s_dev.data(), gate_dst_dev.data(),
+                                           2 * moe_inter, gu.data());
+      } else if (use_xe2_gemm) {
           matmul_nvfp4_grouped_rows_xe2(ctx, xe_packed.data(), xe_scale.data(), H,
                                         row_expert_dev.data(), A_all,
                                         gate_w_dev.data(), gate_s_dev.data(), gate_dst_dev.data(),
@@ -417,7 +434,12 @@ static bool run_shard_nvfp4_gpu_layout(
 
     auto Ye = ar.alloc<bf16>((size_t)A_all * H);
     { DIFF_PROF(q, prof.down_mm);
-      if (use_xe2_gemm) {
+      if (use_xe2v2) {
+          matmul_nvfp4_grouped_rows_xe2_v2(ctx, act_packed.data(), act_scale.data(), moe_inter,
+                                           expert_offsets_dev.data(), rows_per_expert_dev.data(), localE,
+                                           down_w_dev.data(), down_s_dev.data(), down_dst_dev.data(),
+                                           H, Ye.data());
+      } else if (use_xe2_gemm) {
           matmul_nvfp4_grouped_rows_xe2(ctx, act_packed.data(), act_scale.data(), moe_inter,
                                         row_expert_dev.data(), A_all,
                                         down_w_dev.data(), down_s_dev.data(), down_dst_dev.data(),

--- a/src/common/gpu/expert_parallel.cpp
+++ b/src/common/gpu/expert_parallel.cpp
@@ -15,6 +15,20 @@ namespace {
 static constexpr int kTailCap = 64;
 static int round_up(int v, int m) { return (v + m - 1) / m * m; }
 
+// Tail capacity for the batched cold-expert GEMM.  Cold experts each occupy T
+// padded rows; experts hotter than T spill to exact-size GEMMs.  Larger T moves
+// more experts into the (padded) batched path; smaller T tightens padding waste
+// but pushes more experts onto the per-expert exact path.  Hot-path tuning knob
+// for the MoE load distribution (inspect with DIFF_MOE_STATS).
+static int moe_tail_cap() {
+    static int value = [] {
+        const char* env = std::getenv("DIFF_MOE_TAIL_CAP");
+        int v = env ? std::atoi(env) : kTailCap;
+        return v > 0 ? v : kTailCap;
+    }();
+    return value;
+}
+
 // Expert activations are carved from the per-GPU liveness arena (see arena.hpp).
 // run_shard allocates ~16 temporaries per layer per pass; the arena hands them
 // out from a pre-sized device chunk (no per-call sycl::malloc churn — the same
@@ -501,7 +515,7 @@ static void run_shard(
     q.memset(out, 0, (size_t)seq * H * sizeof(bf16));
     if (A == 0) return;
 
-    int T = std::min(kTailCap, round_up(seq, 8));
+    int T = std::min(moe_tail_cap(), round_up(seq, 8));
     bool q8_compact_exact = shard.q8 && !q8_use_hybrid_expert_kernel();
     struct Hot { int expert, rows_off, m; };
     std::vector<Hot> hot;

--- a/src/common/gpu/nvfp4.hpp
+++ b/src/common/gpu/nvfp4.hpp
@@ -747,3 +747,104 @@ inline void matmul_nvfp4_grouped_rows_xe2(
             });
     });
 }
+
+// xe2v2: per-expert DPAS grouped NVFP4 GEMM, aligned to the xe2 idiom.
+// Replaces the k-split + SLM-reduction + global-LUT dequant of the v1 xe2
+// kernel with a single-subgroup, register-blocked-M design (cf. the q8
+// grouped-expert kernel): one work-group per (expert, N/16 tile), BLK M-tiles
+// resident in registers, B dequanted once per k-step and reused across BLK
+// rows, arithmetic e2m1*e4m3 dequant (no lookup table, no global traffic).
+// Per-expert work-groups make the row->expert mapping exact (no tile straddles
+// into another expert's weights), so correctness does not rely on per-expert row
+// padding. Gated by DIFF_NVFP4_GROUPED_GEMM=xe2v2 for A/B vs hybrid/oneDNN.
+inline void matmul_nvfp4_grouped_rows_xe2_v2(
+    GpuEngine& ctx,
+    const uint8_t* A_packed,
+    const uint8_t* A_scale,
+    int K,
+    const int32_t* expert_offsets,
+    const int32_t* rows_per_expert,
+    int localE,
+    const uint8_t* const* W_packed_by_expert,
+    const uint8_t* const* W_scale_by_expert,
+    const float* const* dst_scale_by_expert,
+    int N,
+    bf16* C)
+{
+    if (K % 16 != 0 || N % 16 != 0)
+        throw std::runtime_error("xe2v2 grouped NVFP4 matmul requires K%16 and N%16");
+    if (localE <= 0) return;
+    constexpr int BLK = 4;
+    auto& q = ctx.queue;
+    int halfK = K / 2;
+    int ktiles = K / 16;
+    int ntiles = N / 16;
+
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(
+            sycl::nd_range<2>(sycl::range<2>((size_t)localE, (size_t)ntiles * 16),
+                              sycl::range<2>(1, 16)),
+            [=](sycl::nd_item<2> it) [[sycl::reqd_sub_group_size(16)]] {
+                int e = (int)it.get_group(0);
+                int lane = (int)it.get_local_id(1);
+                int n = (int)it.get_group(1) * 16 + lane;
+                int offset = expert_offsets[e];
+                int count = rows_per_expert[e];
+                if (count <= 0) return;
+                int mt = (count + 7) / 8;
+
+                const uint8_t* w = W_packed_by_expert[e];
+                const uint8_t* ws = W_scale_by_expert[e];
+                const uint8_t* wrow_base = w + (size_t)n * halfK;
+                float inv_dst = 1.0f / dst_scale_by_expert[e][0];
+
+                for (int tile0 = 0; tile0 < mt; tile0 += BLK) {
+                    diff_dpas_v8f c[BLK];
+                    for (int t = 0; t < BLK; ++t) c[t] = diff_dpas_v8f{0, 0, 0, 0, 0, 0, 0, 0};
+                    for (int kt = 0; kt < ktiles; ++kt) {
+                        int k0 = kt * 16;
+                        float wscale = nvfp4_e4m3_fast(ws[(size_t)kt * N + n]);
+                        const uint8_t* wrow = wrow_base + k0 / 2;
+                        diff_dpas_v8i b;
+                        for (int j = 0; j < 8; ++j) {
+                            uint8_t by = wrow[j];
+                            uint16_t lo = float_to_bf16(nvfp4_e2m1_fast(by & 0x0f) * wscale);
+                            uint16_t hi = float_to_bf16(nvfp4_e2m1_fast(by >> 4) * wscale);
+                            b[j] = (int)((uint32_t)lo | ((uint32_t)hi << 16));
+                        }
+                        int kk = k0 + lane;
+                        for (int t = 0; t < BLK; ++t) {
+                            int tile = tile0 + t;
+                            if (tile >= mt) break;  // uniform across the subgroup
+                            int m0 = offset + tile * 8;
+                            diff_dpas_v8s a;
+                            for (int m = 0; m < 8; ++m) {
+                                int row = m0 + m;
+                                uint16_t av = 0;
+                                if ((row - offset) < count) {
+                                    uint8_t byte = A_packed[(size_t)row * halfK + kk / 2];
+                                    uint8_t nib = (kk & 1) ? (byte >> 4) : (byte & 0x0f);
+                                    av = float_to_bf16(
+                                        nvfp4_e2m1_fast(nib) *
+                                        nvfp4_e4m3_fast(A_scale[(size_t)row * ktiles + kt]));
+                                }
+                                a[m] = (short)av;
+                            }
+                            c[t] = __spirv_SubgroupMatrixMultiplyAccumulateINTEL(
+                                16, a, b, c[t], kNvfp4DpasBF16);
+                        }
+                    }
+                    for (int t = 0; t < BLK; ++t) {
+                        int tile = tile0 + t;
+                        if (tile >= mt) break;
+                        int m0 = offset + tile * 8;
+                        for (int m = 0; m < 8; ++m) {
+                            int row = m0 + m;
+                            if ((row - offset) < count)
+                                C[(size_t)row * N + n] = float_to_bf16(c[t][m] * inv_dst);
+                        }
+                    }
+                }
+            });
+    });
+}

--- a/src/common/gpu/q8_0.hpp
+++ b/src/common/gpu/q8_0.hpp
@@ -849,3 +849,34 @@ inline void embedding_lookup_q8_0(
         });
     });
 }
+
+// out[t, :] = scale * sum_{s<k} w[t,s] * dequant(table[idx[t,s], :])   (Q8_0 table)
+// Top-k weighted embedding gather; counterpart to weighted_embed_gather for BF16.
+inline void weighted_embed_gather_q8_0(
+    sycl::queue& q,
+    const Q8Linear& table,
+    const int32_t* idx,    // (seq, k)
+    const float* w,        // (seq, k)
+    bf16* out,             // (seq, H)
+    int seq, int k, int H,
+    float scale)
+{
+    if (table.in_features != H || table.weight_scale_rows.empty())
+        throw std::runtime_error("weighted_embed_gather_q8_0: invalid Q8_0 embedding table");
+    const int8_t* qs = table.weight_qs.data();
+    const float* sc = table.weight_scale_rows.data();
+    int groups = H / 32;
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::range<2>(seq, H), [=](sycl::id<2> id) {
+            int t = (int)id[0], d = (int)id[1];
+            float acc = 0.0f;
+            for (int s = 0; s < k; ++s) {
+                int tok = idx[(size_t)t * k + s];
+                float val = (float)qs[(size_t)tok * H + d] *
+                            sc[(size_t)tok * groups + d / 32];
+                acc += w[(size_t)t * k + s] * val;
+            }
+            out[(size_t)t * H + d] = float_to_bf16(acc * scale);
+        });
+    });
+}

--- a/src/modeling/diffusion_gemma/device_sampler.hpp
+++ b/src/modeling/diffusion_gemma/device_sampler.hpp
@@ -1,0 +1,158 @@
+#pragma once
+// Device-resident block-diffusion sampler + stopping kernels.
+//
+// These replace the per-step host round-trip in the denoising loop: instead of
+// downloading argmax/entropy/denoiser every step, running the entropy-bound
+// accept/renoise sampler and the stable-and-confident stop check on the CPU,
+// and re-uploading the renoised canvas, the canvas / argmax / entropy / denoiser
+// stay on the GPU and the sampler + stopping run as small kernels on the same
+// in-order queue.  The only host sync per step is the 4-byte stop flag needed to
+// break the loop (skipped entirely when DIFF_FORCE_DENOISE_STEPS is set).
+//
+// The device RNG is a deterministic counter-based hash; it does NOT match the
+// host std::mt19937 path (kept under DIFF_HOST_SAMPLER) bit-for-bit.  Sampler
+// RNG is not required to match HF exactly -- validation is at the per-step
+// logits / argmax-canvas level (see notes/diffusion_gemma/...Architecture.md).
+//
+// All kernels target one canvas of `seq <= 256` positions (canvas_length = 256)
+// and run as a single work-group of WG = 256 threads.
+#include <cstdint>
+#include <sycl/sycl.hpp>
+
+namespace diffsamp {
+
+inline constexpr int kMaxCanvas = 256;
+
+// Counter-based device RNG: a well-mixed uint32 from (seed, a, b, c).
+// Used for canvas init, per-step renoise, and sampling uniforms.
+inline uint32_t rng_u32(uint64_t seed, uint32_t a, uint32_t b, uint32_t c) {
+    uint64_t x = seed + 0x9e3779b97f4a7c15ULL;
+    x ^= (uint64_t)a * 0x9e3779b97f4a7c15ULL;
+    x ^= (uint64_t)b * 0xbf58476d1ce4e5b9ULL;
+    x ^= (uint64_t)c * 0x94d049bb1335ebULL;
+    // splitmix64 finalizer
+    x += 0x9e3779b97f4a7c15ULL;
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb1335ebULL;
+    x ^= x >> 31;
+    return (uint32_t)(x >> 32);
+}
+
+// Fill `canvas` (seq int32) with uniform-random tokens in [0, V).
+// V must divide 2^32 for an unbiased % (true for V = 262144 = 2^18).
+inline void init_canvas_random(sycl::queue& q, int32_t* canvas,
+                               uint64_t seed, uint32_t block, int seq, int V) {
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::range<1>(seq), [=](sycl::id<1> idx) {
+            int i = (int)idx[0];
+            canvas[i] = (int32_t)(rng_u32(seed, block, 0, (uint32_t)i) % (uint32_t)V);
+        });
+    });
+}
+
+// Fill `u` (seq float) with uniform [0,1) sampling variates for fused_logits_head.
+inline void fill_uniform(sycl::queue& q, float* u,
+                         uint64_t seed, uint32_t block, uint32_t step, int seq) {
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::range<1>(seq), [=](sycl::id<1> idx) {
+            int i = (int)idx[0];
+            uint32_t r = rng_u32(seed, block, step, (uint32_t)i);
+            u[i] = (float)(r >> 8) * (1.0f / 16777216.0f);   // [0,1)
+        });
+    });
+}
+
+// Entropy-bound accept + renoise, in place over the canvas.
+//
+// For each position i: sort-stable by (entropy, index); let prefix[i] be the
+// sum of entropies of the positions that sort strictly before i.  Accept i iff
+// prefix[i] <= entropy_bound (matches the host sampler's cumulative-bound rule).
+// Accepted positions take the denoiser token; rejected positions are renoised
+// with a fresh uniform-random token (staying on the uniform-noise manifold).
+//
+// O(seq^2) per position, one work-group of WG = kMaxCanvas; seq <= kMaxCanvas.
+inline void entropy_bound_renoise(sycl::queue& q,
+                                  int32_t* canvas, const int32_t* denoiser,
+                                  const float* entropy, char* accepted,
+                                  uint64_t seed, uint32_t block, uint32_t step,
+                                  int seq, float entropy_bound, int V) {
+    q.submit([&](sycl::handler& h) {
+        sycl::local_accessor<float, 1> ent(sycl::range<1>(kMaxCanvas), h);
+        h.parallel_for(
+            sycl::nd_range<1>(sycl::range<1>(kMaxCanvas), sycl::range<1>(kMaxCanvas)),
+            [=](sycl::nd_item<1> it) {
+                int i = (int)it.get_local_id(0);
+                if (i < seq) ent[i] = entropy[i];
+                it.barrier(sycl::access::fence_space::local_space);
+                if (i < seq) {
+                    float ei = ent[i];
+                    float prefix = 0.0f;
+                    for (int j = 0; j < seq; ++j) {
+                        float ej = ent[j];
+                        // strict sort key (entropy[j], j) < (entropy[i], i)
+                        bool before = (ej < ei) || (ej == ei && j < i);
+                        if (before) prefix += ej;
+                    }
+                    bool accept = (prefix <= entropy_bound);
+                    int32_t tok = accept
+                        ? denoiser[i]
+                        : (int32_t)(rng_u32(seed, block, step, (uint32_t)i) % (uint32_t)V);
+                    canvas[i] = tok;
+                    accepted[i] = accept ? 1 : 0;
+                }
+            });
+    });
+}
+
+// Stable-and-confident stopping, device-side.  Computes:
+//   mean      = mean(entropy)
+//   stable    = (stability_threshold == 0) || (!first_step && argmax == prev_argmax)
+//   confident = mean < confidence_threshold
+//   stop      = stable && confident
+// Writes mean -> *mean_out and stop -> *stop_out, then copies argmax -> prev_argmax
+// for the next step (so callers keep `prev_argmax` device-resident).
+inline void stopping_check(sycl::queue& q,
+                           const int32_t* argmax, int32_t* prev_argmax,
+                           const float* entropy,
+                           float* mean_out, int32_t* stop_out,
+                           float confidence_threshold, int stability_threshold,
+                           bool first_step, int seq) {
+    q.submit([&](sycl::handler& h) {
+        sycl::local_accessor<float, 1>  sent(sycl::range<1>(kMaxCanvas), h);
+        sycl::local_accessor<int32_t, 1> sarg(sycl::range<1>(kMaxCanvas), h);
+        sycl::local_accessor<int32_t, 1> sprev(sycl::range<1>(kMaxCanvas), h);
+        h.parallel_for(
+            sycl::nd_range<1>(sycl::range<1>(kMaxCanvas), sycl::range<1>(kMaxCanvas)),
+            [=](sycl::nd_item<1> it) {
+                int i = (int)it.get_local_id(0);
+                if (i < seq) {
+                    sent[i]  = entropy[i];
+                    sarg[i]  = argmax[i];
+                    sprev[i] = first_step ? 0 : prev_argmax[i];
+                } else {
+                    sent[i] = 0.0f; sarg[i] = 0; sprev[i] = 0;
+                }
+                it.barrier(sycl::access::fence_space::local_space);
+                if (i == 0) {
+                    float sum = 0.0f;
+                    int eq = 0;
+                    for (int j = 0; j < seq; ++j) {
+                        sum += sent[j];
+                        if (sarg[j] == sprev[j]) eq++;
+                    }
+                    float mean = sum / (float)seq;
+                    bool all_eq = (eq == seq);
+                    bool stable = (stability_threshold == 0)
+                                ? true
+                                : (!first_step && all_eq);
+                    bool confident = mean < confidence_threshold;
+                    *mean_out = mean;
+                    *stop_out = (stable && confident) ? 1 : 0;
+                }
+                // copy argmax -> prev_argmax for the next step
+                if (i < seq) prev_argmax[i] = sarg[i];
+            });
+    });
+}
+
+}  // namespace diffsamp

--- a/src/modeling/diffusion_gemma/fusions/logits.hpp
+++ b/src/modeling/diffusion_gemma/fusions/logits.hpp
@@ -136,6 +136,110 @@ inline void fused_logits_head(
 }
 
 // ---------------------------------------------------------------------------
+// F1c — top-k soft-conditioning select.  Per canvas row, find the top-k tokens
+// of the softcapped/tempered distribution and their renormalized softmax
+// weights, WITHOUT materializing the (seq,V) probs buffer.  Feeds a top-k
+// weighted embedding gather (see weighted_embed_gather*) so the next-step
+// self-conditioning signal costs k*H per row instead of the full V*H GEMM —
+// the accuracy-preserving middle ground between exact probs@embed and the
+// argmax-only "hard" path.
+//
+// Z cancels under top-k renormalization, so only the global max is needed for
+// numerical stability: weight_i = exp(proc_i - m) / sum_{j in topk} exp(proc_j - m).
+// Selection is k parallel argmax passes (k*V work, still << V*H), masking
+// already-picked columns — same construction as the MoE router top-k.
+// ---------------------------------------------------------------------------
+inline void topk_soft_select(
+    sycl::queue& q,
+    const bf16* logits,    // (seq, V)
+    float softcap, float inv_temp,
+    int k,
+    int32_t* topk_idx,     // (seq, k)
+    float*   topk_w,       // (seq, k) renormalized softmax weights
+    int seq, int V)
+{
+    constexpr int WG = 256;
+    q.submit([&](sycl::handler& h) {
+        sycl::local_accessor<float, 1> sf(sycl::range<1>(WG), h);
+        sycl::local_accessor<int, 1>   si(sycl::range<1>(WG), h);
+        sycl::local_accessor<int, 1>   sel(sycl::range<1>(k), h);
+        sycl::local_accessor<float, 1> selv(sycl::range<1>(k), h);
+        h.parallel_for(
+            sycl::nd_range<1>((size_t)seq * WG, WG),
+            [=](sycl::nd_item<1> it) {
+                int row = it.get_group(0);
+                int lid = it.get_local_id(0);
+                const bf16* x = logits + (size_t)row * V;
+
+                auto proc = [=](int c) {
+                    float v = bf16_to_float(x[c]);
+                    return sycl::tanh(v / softcap) * softcap * inv_temp;
+                };
+
+                for (int s = 0; s < k; ++s) {
+                    // Parallel argmax over columns not already selected.
+                    float m = -3.4028235e38f; int am = -1;
+                    for (int c = lid; c < V; c += WG) {
+                        bool taken = false;
+                        for (int j = 0; j < s; ++j) if (sel[j] == c) { taken = true; break; }
+                        if (taken) continue;
+                        float p = proc(c);
+                        if (p > m || (p == m && (am < 0 || c < am))) { m = p; am = c; }
+                    }
+                    sf[lid] = m; si[lid] = am;
+                    it.barrier(sycl::access::fence_space::local_space);
+                    for (int o = WG / 2; o > 0; o >>= 1) {
+                        if (lid < o) {
+                            if (sf[lid + o] > sf[lid] ||
+                                (sf[lid + o] == sf[lid] && si[lid + o] >= 0 &&
+                                 (si[lid] < 0 || si[lid + o] < si[lid]))) {
+                                sf[lid] = sf[lid + o]; si[lid] = si[lid + o];
+                            }
+                        }
+                        it.barrier(sycl::access::fence_space::local_space);
+                    }
+                    if (lid == 0) { sel[s] = si[0]; selv[s] = sf[0]; }
+                    it.barrier(sycl::access::fence_space::local_space);
+                }
+
+                // Renormalized softmax over the k selected (selv[0] == global max).
+                if (lid == 0) {
+                    float m0 = selv[0];
+                    float z = 0.0f;
+                    for (int s = 0; s < k; ++s) { float e = sycl::exp(selv[s] - m0); selv[s] = e; z += e; }
+                    float inv_z = z > 0.0f ? 1.0f / z : 0.0f;
+                    for (int s = 0; s < k; ++s) {
+                        topk_idx[(size_t)row * k + s] = sel[s];
+                        topk_w[(size_t)row * k + s]   = selv[s] * inv_z;
+                    }
+                }
+            });
+    });
+}
+
+// out[t, :] = scale * sum_{s<k} w[t,s] * table[idx[t,s], :]   (BF16 table)
+inline void weighted_embed_gather(
+    sycl::queue& q,
+    const bf16* table,     // (vocab, H)
+    const int32_t* idx,    // (seq, k)
+    const float* w,        // (seq, k)
+    bf16* out,             // (seq, H)
+    int seq, int k, int H, float scale)
+{
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::range<2>(seq, H), [=](sycl::id<2> id) {
+            int t = (int)id[0], d = (int)id[1];
+            float acc = 0.0f;
+            for (int s = 0; s < k; ++s) {
+                int tok = idx[(size_t)t * k + s];
+                acc += w[(size_t)t * k + s] * bf16_to_float(table[(size_t)tok * H + d]);
+            }
+            out[(size_t)t * H + d] = float_to_bf16(acc * scale);
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
 // F1b — parallel multinomial over probs rows.  Thread k owns a contiguous
 // column chunk; partial sums + local exclusive scan find the chunk containing
 // the target, which is then rescanned serially.

--- a/src/modeling/diffusion_gemma/generate.cpp
+++ b/src/modeling/diffusion_gemma/generate.cpp
@@ -1,7 +1,10 @@
 #include "model.hpp"
 #include "sampler.hpp"
+#include "device_sampler.hpp"
 #include "../../utils/profile.hpp"
+#include "../../common/gpu/engine.hpp"
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <optional>
@@ -29,6 +32,10 @@ std::vector<int> DiffusionGemmaModel::generate(
 
     DiffStopping stopping(cfg_.gen.stability_threshold, cfg_.gen.confidence_threshold);
     bool force_denoise_steps = std::getenv("DIFF_FORCE_DENOISE_STEPS") != nullptr;
+    // DIFF_HOST_SAMPLER: keep the original fully host-side sampler + stopping
+    // (host canvas, host entropy-bound accept/renoise, host stable-and-confident
+    // check) for A/B against the device-resident default path.
+    bool host_sampler = std::getenv("DIFF_HOST_SAMPLER") != nullptr;
     // DIFF_SKIP_LAST_SOFT_NEXT: the final scheduled step (step==1) has no
     // successor to consume its self-conditioning signal, so skip producing it.
     bool skip_last_soft_next = std::getenv("DIFF_SKIP_LAST_SOFT_NEXT") != nullptr;
@@ -48,44 +55,120 @@ std::vector<int> DiffusionGemmaModel::generate(
             stats_.prefill_tokens += (blk == 0) ? (int)prompt_ids.size() : C;
         }
 
-        // 2. Init canvas with uniform-random tokens.
-        std::vector<int> current(C);
-        for (int& t : current) t = uni(rng);
-        std::optional<GpuBuffer<bf16>> soft;
-        stopping.reset();
-        std::vector<int> argmax = current, denoiser;
-        std::vector<float> entropy;
+        // 2-3. Denoise the canvas.  Two paths share the commit tail below:
+        //   * device-resident (default): canvas / argmax / entropy / denoiser
+        //     stay on the GPU; accept/renoise + stable-and-confident stop run as
+        //     small device kernels on the same in-order queue.  The only host
+        //     sync per step is the optional callback payload + 4-byte stop flag.
+        //   * host sampler (DIFF_HOST_SAMPLER): the original path — host canvas,
+        //     host entropy_bound_accept_renoise, host DiffStopping.  Kept for A/B.
+        // Both leave the final denoised canvas in `argmax` (host).
+        std::vector<int> argmax;
 
-        // 3. Denoising loop (cur_step counts down N..1).
-        for (int step = N; step >= 1; --step) {
-            float temp = diff_temperature(step, N, cfg_.gen.t_min, cfg_.gen.t_max);
-            GpuBuffer<bf16> soft_next;
-            bool want_soft_next = !(skip_last_soft_next && step == 1);
-            auto td0 = Clk::now();
-            decode_step(current, soft ? soft->data() : nullptr, enc_len, temp,
-                        argmax, entropy, denoiser, soft_next, rng, want_soft_next);
-            stats_.decode_s += secs(td0, Clk::now());
-            stats_.decode_passes += 1;
+        if (host_sampler) {
+            std::vector<int> current(C);
+            for (int& t : current) t = uni(rng);
+            std::optional<GpuBuffer<bf16>> soft;
+            stopping.reset();
+            argmax = current;
+            std::vector<int> denoiser;
+            std::vector<float> entropy;
 
-            std::vector<char> accepted;
-            current = entropy_bound_accept_renoise(current, denoiser, entropy,
-                                                   cfg_.gen.entropy_bound, V, rng,
-                                                   &accepted);
-            if (want_soft_next) soft.emplace(std::move(soft_next));
+            for (int step = N; step >= 1; --step) {
+                float temp = diff_temperature(step, N, cfg_.gen.t_min, cfg_.gen.t_max);
+                GpuBuffer<bf16> soft_next;
+                bool want_soft_next = !(skip_last_soft_next && step == 1);
+                auto td0 = Clk::now();
+                decode_step(current, soft ? soft->data() : nullptr, enc_len, temp,
+                            argmax, entropy, denoiser, soft_next, rng, want_soft_next);
+                stats_.decode_s += secs(td0, Clk::now());
+                stats_.decode_passes += 1;
 
-            bool stop = stopping.update(argmax, entropy);
-            double me = 0; for (float e : entropy) me += e; me /= entropy.size();
-            if (verbose)
-                std::printf("[blk %d step %2d] temp=%.3f mean_entropy=%.4f%s\n",
-                            blk, step, temp, me, stop ? "  [stop]" : "");
-            if (on_step) {
-                DiffStepEvent ev;
-                ev.block = blk; ev.cur_step = step; ev.temperature = temp;
-                ev.mean_entropy = (float)me; ev.committed = false;
-                ev.canvas = &argmax; ev.entropy = &entropy; ev.accepted = &accepted;
-                on_step(ev);
+                std::vector<char> accepted;
+                current = entropy_bound_accept_renoise(current, denoiser, entropy,
+                                                       cfg_.gen.entropy_bound, V, rng,
+                                                       &accepted);
+                if (want_soft_next) soft.emplace(std::move(soft_next));
+
+                bool stop = stopping.update(argmax, entropy);
+                double me = 0; for (float e : entropy) me += e; me /= entropy.size();
+                if (verbose)
+                    std::printf("[blk %d step %2d] temp=%.3f mean_entropy=%.4f%s\n",
+                                blk, step, temp, me, stop ? "  [stop]" : "");
+                if (on_step) {
+                    DiffStepEvent ev;
+                    ev.block = blk; ev.cur_step = step; ev.temperature = temp;
+                    ev.mean_entropy = (float)me; ev.committed = false;
+                    ev.canvas = &argmax; ev.entropy = &entropy; ev.accepted = &accepted;
+                    on_step(ev);
+                }
+                if (stop && !force_denoise_steps) break;
             }
-            if (stop && !force_denoise_steps) break;
+        } else {
+            ensure_device_buffers(C);
+            auto& q0 = GpuEngine::get(0).queue;
+            diffsamp::init_canvas_random(q0, canvas_dev_.data(), (uint64_t)seed,
+                                         (uint32_t)blk, C, V);
+            std::optional<GpuBuffer<bf16>> soft;
+            GpuBuffer<bf16> soft_next_buf;
+            bool first_step = true;
+            std::vector<float> entropy_h;
+            std::vector<char>  accepted_h;
+
+            for (int step = N; step >= 1; --step) {
+                float temp = diff_temperature(step, N, cfg_.gen.t_min, cfg_.gen.t_max);
+                bool want_soft_next = !(skip_last_soft_next && step == 1);
+                auto td0 = Clk::now();
+
+                diffsamp::fill_uniform(q0, u_dev_.data(), (uint64_t)seed,
+                                       (uint32_t)blk, (uint32_t)step, C);
+                decode_forward(canvas_dev_.data(), soft ? soft->data() : nullptr,
+                               enc_len, C, temp, u_dev_.data(),
+                               argmax_dev_.data(), entropy_dev_.data(),
+                               denoiser_dev_.data(), soft_next_buf, want_soft_next);
+                diffsamp::entropy_bound_renoise(q0, canvas_dev_.data(),
+                                                denoiser_dev_.data(),
+                                                entropy_dev_.data(), accepted_dev_.data(),
+                                                (uint64_t)seed, (uint32_t)blk, (uint32_t)step,
+                                                C, cfg_.gen.entropy_bound, V);
+                diffsamp::stopping_check(q0, argmax_dev_.data(), prev_argmax_dev_.data(),
+                                         entropy_dev_.data(), mean_dev_.data(),
+                                         stop_dev_.data(),
+                                         cfg_.gen.confidence_threshold,
+                                         cfg_.gen.stability_threshold,
+                                         first_step, C);
+                first_step = false;
+                if (want_soft_next) soft.emplace(std::move(soft_next_buf));
+
+                stats_.decode_s += secs(td0, Clk::now());
+                stats_.decode_passes += 1;
+
+                if (on_step || verbose || !force_denoise_steps) {
+                    bool stop = false;
+                    if (!force_denoise_steps) {
+                        int32_t s = 0; stop_dev_.download(&s, 1); stop = (s != 0);
+                    }
+                    double me = 0.0;
+                    if (on_step || verbose) {
+                        entropy_h.resize(C); entropy_dev_.download(entropy_h.data(), C);
+                        for (float e : entropy_h) me += e; me /= C;
+                    }
+                    if (verbose)
+                        std::printf("[blk %d step %2d] temp=%.3f mean_entropy=%.4f%s\n",
+                                    blk, step, temp, me, stop ? "  [stop]" : "");
+                    if (on_step) {
+                        argmax.resize(C); argmax_dev_.download(argmax.data(), C);
+                        accepted_h.resize(C); accepted_dev_.download(accepted_h.data(), C);
+                        DiffStepEvent ev;
+                        ev.block = blk; ev.cur_step = step; ev.temperature = temp;
+                        ev.mean_entropy = (float)me; ev.committed = false;
+                        ev.canvas = &argmax; ev.entropy = &entropy_h; ev.accepted = &accepted_h;
+                        on_step(ev);
+                    }
+                    if (stop && !force_denoise_steps) break;
+                }
+            }
+            if (argmax.empty()) { argmax.resize(C); argmax_dev_.download(argmax.data(), C); }
         }
 
         // 4. Find the first EOS in the denoised canvas; commit up to it.

--- a/src/modeling/diffusion_gemma/generate.cpp
+++ b/src/modeling/diffusion_gemma/generate.cpp
@@ -29,6 +29,9 @@ std::vector<int> DiffusionGemmaModel::generate(
 
     DiffStopping stopping(cfg_.gen.stability_threshold, cfg_.gen.confidence_threshold);
     bool force_denoise_steps = std::getenv("DIFF_FORCE_DENOISE_STEPS") != nullptr;
+    // DIFF_SKIP_LAST_SOFT_NEXT: the final scheduled step (step==1) has no
+    // successor to consume its self-conditioning signal, so skip producing it.
+    bool skip_last_soft_next = std::getenv("DIFF_SKIP_LAST_SOFT_NEXT") != nullptr;
     std::uniform_int_distribution<int> uni(0, V - 1);
 
     std::vector<int> output;
@@ -57,9 +60,10 @@ std::vector<int> DiffusionGemmaModel::generate(
         for (int step = N; step >= 1; --step) {
             float temp = diff_temperature(step, N, cfg_.gen.t_min, cfg_.gen.t_max);
             GpuBuffer<bf16> soft_next;
+            bool want_soft_next = !(skip_last_soft_next && step == 1);
             auto td0 = Clk::now();
             decode_step(current, soft ? soft->data() : nullptr, enc_len, temp,
-                        argmax, entropy, denoiser, soft_next, rng);
+                        argmax, entropy, denoiser, soft_next, rng, want_soft_next);
             stats_.decode_s += secs(td0, Clk::now());
             stats_.decode_passes += 1;
 
@@ -67,7 +71,7 @@ std::vector<int> DiffusionGemmaModel::generate(
             current = entropy_bound_accept_renoise(current, denoiser, entropy,
                                                    cfg_.gen.entropy_bound, V, rng,
                                                    &accepted);
-            soft.emplace(std::move(soft_next));
+            if (want_soft_next) soft.emplace(std::move(soft_next));
 
             bool stop = stopping.update(argmax, entropy);
             double me = 0; for (float e : entropy) me += e; me /= entropy.size();

--- a/src/modeling/diffusion_gemma/model.cpp
+++ b/src/modeling/diffusion_gemma/model.cpp
@@ -16,9 +16,28 @@
 #include <string>
 #include <vector>
 
+// DIFF_PERSIST_XFER_STAGE: reuse the host staging buffer across cross-GPU hops
+// instead of allocating a fresh std::vector on each call (the split decode path
+// hops twice per step).  Default off; identical bytes either way.
+static bool persist_xfer_stage_enabled() {
+    static bool enabled = [] {
+        const char* e = std::getenv("DIFF_PERSIST_XFER_STAGE");
+        return e && std::strcmp(e, "0") && std::strcmp(e, "off") &&
+               std::strcmp(e, "false") && std::strcmp(e, "no");
+    }();
+    return enabled;
+}
+
 // Cross-GPU copy via host staging (devices have no P2P here).
 static void transfer(sycl::queue& src_q, const bf16* src,
                      sycl::queue& dst_q, bf16* dst, size_t n) {
+    if (persist_xfer_stage_enabled()) {
+        static thread_local std::vector<bf16> stage;
+        if (stage.size() < n) stage.resize(n);
+        src_q.memcpy(stage.data(), src, n * sizeof(bf16)).wait();
+        dst_q.memcpy(dst, stage.data(), n * sizeof(bf16)).wait();
+        return;
+    }
     std::vector<bf16> stage(n);
     src_q.memcpy(stage.data(), src, n * sizeof(bf16)).wait();
     dst_q.memcpy(dst, stage.data(), n * sizeof(bf16)).wait();
@@ -150,7 +169,8 @@ void DiffusionGemmaModel::encode_block(const std::vector<int>& ids, int past_len
 void DiffusionGemmaModel::decode_step(
     const std::vector<int>& canvas_ids, const bf16* soft_or_null, int enc_len,
     float temp, std::vector<int>& argmax, std::vector<float>& entropy,
-    std::vector<int>& denoiser, GpuBuffer<bf16>& soft_next, std::mt19937& rng)
+    std::vector<int>& denoiser, GpuBuffer<bf16>& soft_next, std::mt19937& rng,
+    bool want_soft_next)
 {
     int seq = (int)canvas_ids.size();
     int H = cfg_.text.hidden_size;
@@ -207,7 +227,7 @@ void DiffusionGemmaModel::decode_step(
     // sample in one kernel.  BF16 probabilities are only materialized when the
     // exact self-conditioning matmul needs them (see SoftNextMode).
     SoftNextCfg sn = soft_next_cfg();
-    bool need_probs = (sn.mode == SoftNextMode::Exact);
+    bool need_probs = want_soft_next && (sn.mode == SoftNextMode::Exact);
     diffarena::Alloc<bf16> probs_bf16;
     if (need_probs) probs_bf16 = ar0.alloc<bf16>((size_t)seq * V);
     GpuBuffer<int32_t> amax_dev(seq, q0), deno_dev(seq, q0);
@@ -225,7 +245,7 @@ void DiffusionGemmaModel::decode_step(
     // the logits buffer is released.
     GpuBuffer<int32_t> topk_idx_dev;
     GpuBuffer<float>   topk_w_dev;
-    if (sn.mode == SoftNextMode::TopK) {
+    if (want_soft_next && sn.mode == SoftNextMode::TopK) {
         topk_idx_dev = GpuBuffer<int32_t>((size_t)seq * sn.k, q0);
         topk_w_dev   = GpuBuffer<float>((size_t)seq * sn.k, q0);
         DIFF_PROF(q0, "lm.topk_select");
@@ -242,6 +262,8 @@ void DiffusionGemmaModel::decode_step(
       ent_dev.download(entropy.data(), seq);
       for (int i = 0; i < seq; ++i) { argmax[i] = a[i]; denoiser[i] = d[i]; } }
     // soft_next: next-step self-conditioning signal (embed_scale_ folded in).
+    // Skipped on the final step, whose signal would never be consumed.
+    if (!want_soft_next) { soft_next = GpuBuffer<bf16>(); q0.wait(); return; }
     soft_next = GpuBuffer<bf16>((size_t)seq * H, q0);
     { DIFF_PROF(q0, "lm.soft_next");
       switch (sn.mode) {

--- a/src/modeling/diffusion_gemma/model.cpp
+++ b/src/modeling/diffusion_gemma/model.cpp
@@ -166,13 +166,34 @@ void DiffusionGemmaModel::encode_block(const std::vector<int>& ids, int past_len
 }
 
 // ---------------------------------------------------------------------------
-void DiffusionGemmaModel::decode_step(
-    const std::vector<int>& canvas_ids, const bf16* soft_or_null, int enc_len,
-    float temp, std::vector<int>& argmax, std::vector<float>& entropy,
-    std::vector<int>& denoiser, GpuBuffer<bf16>& soft_next, std::mt19937& rng,
-    bool want_soft_next)
+// Persistent device buffers for the device-resident denoising loop.  Sized for
+// one canvas (seq <= canvas_length); reallocated only if the canvas grows.
+void DiffusionGemmaModel::ensure_device_buffers(int seq) {
+    if (dev_buf_seq_ >= seq && !canvas_dev_.empty()) return;
+    auto& q0 = GpuEngine::get(0).queue;
+    canvas_dev_      = GpuBuffer<int32_t>(seq, q0);
+    argmax_dev_      = GpuBuffer<int32_t>(seq, q0);
+    denoiser_dev_    = GpuBuffer<int32_t>(seq, q0);
+    prev_argmax_dev_ = GpuBuffer<int32_t>(seq, q0);
+    entropy_dev_     = GpuBuffer<float>(seq, q0);
+    u_dev_           = GpuBuffer<float>(seq, q0);
+    mean_dev_        = GpuBuffer<float>(1, q0);
+    stop_dev_        = GpuBuffer<int32_t>(1, q0);
+    accepted_dev_    = GpuBuffer<char>(seq, q0);
+    dev_buf_seq_ = seq;
+}
+
+// Device-only denoiser forward: the embed→layers→LM-head→sample→soft_next
+// pipeline with no host round-trip.  Extracted from the original decode_step;
+// the host-sampler path (decode_step below) wraps this and downloads the
+// per-step outputs.  Does not call q0.wait() — callers sync via download()
+// (host path) or rely on the in-order queue (device-resident path).
+void DiffusionGemmaModel::decode_forward(
+    const int32_t* ids, const bf16* soft_or_null, int enc_len, int seq,
+    float temp, const float* u_dev,
+    int32_t* argmax_dev, float* entropy_dev, int32_t* denoiser_dev,
+    GpuBuffer<bf16>& soft_next, bool want_soft_next)
 {
-    int seq = (int)canvas_ids.size();
     int H = cfg_.text.hidden_size;
     int L = cfg_.text.num_hidden_layers;
     int V = cfg_.text.vocab_size;
@@ -180,16 +201,14 @@ void DiffusionGemmaModel::decode_step(
     auto& q0 = ctx0.queue;
 
     // Embed canvas + self-conditioning.
-    GpuBuffer<int32_t> ids_dev(seq, q0);
-    { std::vector<int32_t> tmp(canvas_ids.begin(), canvas_ids.end()); ids_dev.upload(tmp.data(), seq); }
     auto& ar0 = diffarena::arena(ctx0.index);
     auto hidden = ar0.alloc<bf16>((size_t)seq * H);
     { DIFF_PROF(q0, "embed+selfcond");
       if (!w_.embed_tokens_q8.empty())
-          embedding_lookup_q8_0(q0, w_.embed_tokens_q8, ids_dev.data(), hidden.data(),
+          embedding_lookup_q8_0(q0, w_.embed_tokens_q8, ids, hidden.data(),
                                 seq, H, embed_scale_);
       else
-          embedding_lookup(q0, w_.embed_tokens.data(), ids_dev.data(), hidden.data(),
+          embedding_lookup(q0, w_.embed_tokens.data(), ids, hidden.data(),
                            seq, H, embed_scale_);
       self_conditioning_forward(ctx0, w_.self_cond, hidden.data(), soft_or_null,
                                 seq, H, cfg_.text.intermediate_size, cfg_.text.rms_norm_eps); }
@@ -230,16 +249,11 @@ void DiffusionGemmaModel::decode_step(
     bool need_probs = want_soft_next && (sn.mode == SoftNextMode::Exact);
     diffarena::Alloc<bf16> probs_bf16;
     if (need_probs) probs_bf16 = ar0.alloc<bf16>((size_t)seq * V);
-    GpuBuffer<int32_t> amax_dev(seq, q0), deno_dev(seq, q0);
-    GpuBuffer<float>   ent_dev(seq, q0);
-    std::vector<float> u(seq);
-    { std::uniform_real_distribution<float> d(0.0f, 1.0f); for (auto& x : u) x = d(rng); }
-    GpuBuffer<float> u_dev(seq, q0); u_dev.upload(u.data(), seq);
     { DIFF_PROF(q0, "lm.softmax_sample");
       fused_logits_head(q0, logits_bf16.data(),
                         cfg_.text.final_logit_softcapping, 1.0f / temp,
-                        u_dev.data(), need_probs ? probs_bf16.data() : nullptr,
-                        amax_dev.data(), ent_dev.data(), deno_dev.data(), seq, V); }
+                        u_dev, need_probs ? probs_bf16.data() : nullptr,
+                        argmax_dev, entropy_dev, denoiser_dev, seq, V); }
 
     // TopK soft_next reads the same logits for its selection — extract before
     // the logits buffer is released.
@@ -255,33 +269,27 @@ void DiffusionGemmaModel::decode_step(
     }
     logits_bf16.reset();
 
-    argmax.resize(seq); entropy.resize(seq); denoiser.resize(seq);
-    { DIFF_PROF(q0, "lm.download");
-      std::vector<int32_t> a(seq), d(seq);
-      amax_dev.download(a.data(), seq); deno_dev.download(d.data(), seq);
-      ent_dev.download(entropy.data(), seq);
-      for (int i = 0; i < seq; ++i) { argmax[i] = a[i]; denoiser[i] = d[i]; } }
     // soft_next: next-step self-conditioning signal (embed_scale_ folded in).
     // Skipped on the final step, whose signal would never be consumed.
-    if (!want_soft_next) { soft_next = GpuBuffer<bf16>(); q0.wait(); return; }
+    if (!want_soft_next) { soft_next = GpuBuffer<bf16>(); return; }
     soft_next = GpuBuffer<bf16>((size_t)seq * H, q0);
     { DIFF_PROF(q0, "lm.soft_next");
       switch (sn.mode) {
       case SoftNextMode::Hard:
           // Gather the argmax token embedding.
           if (!w_.embed_tokens_q8.empty())
-              embedding_lookup_q8_0(q0, w_.embed_tokens_q8, amax_dev.data(),
+              embedding_lookup_q8_0(q0, w_.embed_tokens_q8, argmax_dev,
                                     soft_next.data(), seq, H, embed_scale_);
           else
-              embedding_lookup(q0, w_.embed_tokens.data(), amax_dev.data(),
+              embedding_lookup(q0, w_.embed_tokens.data(), argmax_dev,
                                soft_next.data(), seq, H, embed_scale_);
           break;
       case SoftNextMode::TopK:
           // Top-k weighted embedding gather.
           if (!w_.embed_tokens_q8.empty())
               weighted_embed_gather_q8_0(q0, w_.embed_tokens_q8, topk_idx_dev.data(),
-                                         topk_w_dev.data(), soft_next.data(),
-                                         seq, sn.k, H, embed_scale_);
+                                          topk_w_dev.data(), soft_next.data(),
+                                          seq, sn.k, H, embed_scale_);
           else
               weighted_embed_gather(q0, w_.embed_tokens.data(), topk_idx_dev.data(),
                                     topk_w_dev.data(), soft_next.data(),
@@ -299,5 +307,38 @@ void DiffusionGemmaModel::decode_step(
           scale_inplace(q0, soft_next.data(), seq * H, embed_scale_);
           break;
       } }
-    q0.wait();
+}
+
+// Host-sampler wrapper: the original per-step decode path (kept under
+// DIFF_HOST_SAMPLER for A/B).  Uploads the canvas + host-drawn uniforms, runs
+// the device-only decode_forward, then downloads argmax / entropy / denoiser
+// for the host entropy-bound sampler and host stopping check.  download() syncs
+// the in-order queue, so soft_next is also complete on return.
+void DiffusionGemmaModel::decode_step(
+    const std::vector<int>& canvas_ids, const bf16* soft_or_null, int enc_len,
+    float temp, std::vector<int>& argmax, std::vector<float>& entropy,
+    std::vector<int>& denoiser, GpuBuffer<bf16>& soft_next, std::mt19937& rng,
+    bool want_soft_next)
+{
+    int seq = (int)canvas_ids.size();
+    auto& q0 = GpuEngine::get(0).queue;
+
+    GpuBuffer<int32_t> ids_dev(seq, q0);
+    { std::vector<int32_t> tmp(canvas_ids.begin(), canvas_ids.end()); ids_dev.upload(tmp.data(), seq); }
+    GpuBuffer<int32_t> amax_dev(seq, q0), deno_dev(seq, q0);
+    GpuBuffer<float>   ent_dev(seq, q0);
+    std::vector<float> u(seq);
+    { std::uniform_real_distribution<float> d(0.0f, 1.0f); for (auto& x : u) x = d(rng); }
+    GpuBuffer<float> u_dev(seq, q0); u_dev.upload(u.data(), seq);
+
+    decode_forward(ids_dev.data(), soft_or_null, enc_len, seq, temp, u_dev.data(),
+                   amax_dev.data(), ent_dev.data(), deno_dev.data(),
+                   soft_next, want_soft_next);
+
+    argmax.resize(seq); entropy.resize(seq); denoiser.resize(seq);
+    { DIFF_PROF(q0, "lm.download");
+      std::vector<int32_t> a(seq), d(seq);
+      amax_dev.download(a.data(), seq); deno_dev.download(d.data(), seq);
+      ent_dev.download(entropy.data(), seq);
+      for (int i = 0; i < seq; ++i) { argmax[i] = a[i]; denoiser[i] = d[i]; } }
 }

--- a/src/modeling/diffusion_gemma/model.cpp
+++ b/src/modeling/diffusion_gemma/model.cpp
@@ -24,21 +24,47 @@ static void transfer(sycl::queue& src_q, const bf16* src,
     dst_q.memcpy(dst, stage.data(), n * sizeof(bf16)).wait();
 }
 
-// Cheap self-conditioning signal.  The exact path materializes BF16 probs over
-// the whole vocab and forms soft_next = probs(seq,V) @ embed(V,H) — a vocab-wide
-// GEMM as expensive as the LM head itself.  The "hard" path instead gathers the
-// argmax token's embedding (seq,H), skipping both the probs buffer and the GEMM.
-// Works for Q8_0 and BF16 embedding tables.  DIFF_SOFT_NEXT=hard|argmax enables
-// it (DIFF_Q8_SOFT_NEXT kept for back-compat with the original Q8-only flag).
-static bool hard_soft_next_enabled() {
-    static bool enabled = [] {
-        auto on = [](const char* env) {
-            return env && (!std::strcmp(env, "argmax") || !std::strcmp(env, "hard") ||
-                           !std::strcmp(env, "1") || !std::strcmp(env, "on"));
+// Self-conditioning ("soft_next") signal modes — a per-step hot-path knob for
+// the next-step conditioning embedding, selected by DIFF_SOFT_NEXT:
+//   exact (default)  soft_next = probs(seq,V) @ embed(V,H).  Faithful, but a
+//                    vocab-wide GEMM as expensive as the LM head, plus a seq*V
+//                    probs buffer.
+//   hard | argmax    gather the argmax token's embedding (seq,H).  Cheapest;
+//                    drops both the probs buffer and the GEMM.
+//   topk[:K]         top-K weighted embedding (default K=8).  Accuracy-
+//                    preserving middle ground: k*H per row, no probs buffer.
+// DIFF_Q8_SOFT_NEXT is honored for back-compat with the original Q8-only flag.
+enum class SoftNextMode { Exact, Hard, TopK };
+struct SoftNextCfg { SoftNextMode mode; int k; };
+
+static SoftNextCfg soft_next_cfg() {
+    static SoftNextCfg cfg = [] {
+        auto parse = [](const char* e, SoftNextCfg& out) -> bool {
+            if (!e) return false;
+            if (!std::strcmp(e, "argmax") || !std::strcmp(e, "hard") ||
+                !std::strcmp(e, "1") || !std::strcmp(e, "on")) {
+                out = {SoftNextMode::Hard, 1}; return true;
+            }
+            if (!std::strcmp(e, "exact") || !std::strcmp(e, "full") ||
+                !std::strcmp(e, "0") || !std::strcmp(e, "off")) {
+                out = {SoftNextMode::Exact, 0}; return true;
+            }
+            if (!std::strncmp(e, "topk", 4)) {
+                int k = 8;
+                const char* colon = std::strchr(e, ':');
+                if (colon) k = std::atoi(colon + 1);
+                k = std::max(1, std::min(k, 64));   // bound local-memory top-k storage
+                out = {SoftNextMode::TopK, k}; return true;
+            }
+            return false;
         };
-        return on(std::getenv("DIFF_SOFT_NEXT")) || on(std::getenv("DIFF_Q8_SOFT_NEXT"));
+        SoftNextCfg out{SoftNextMode::Exact, 0};
+        if (parse(std::getenv("DIFF_SOFT_NEXT"), out) ||
+            parse(std::getenv("DIFF_Q8_SOFT_NEXT"), out))
+            return out;
+        return SoftNextCfg{SoftNextMode::Exact, 0};
     }();
-    return enabled;
+    return cfg;
 }
 
 DiffusionGemmaModel::DiffusionGemmaModel(const std::string& model_dir, int max_seq_len, DiffPlacementOptions placement, bool print_placement) {
@@ -177,12 +203,13 @@ void DiffusionGemmaModel::decode_step(
           matmul_bf16(hidden.data(), seq, H, w_.embed_tokens.data(), V, logits_bf16.data(), ctx0); }
     hidden.reset();
 
-    // F1: softcap + temperature + softmax + argmax + entropy +
-    // multinomial sample in one kernel. Only BF16 probabilities are
-    // materialized for the self-conditioning matmul.
-    bool hard_soft_next = hard_soft_next_enabled();
+    // F1: softcap + temperature + softmax + argmax + entropy + multinomial
+    // sample in one kernel.  BF16 probabilities are only materialized when the
+    // exact self-conditioning matmul needs them (see SoftNextMode).
+    SoftNextCfg sn = soft_next_cfg();
+    bool need_probs = (sn.mode == SoftNextMode::Exact);
     diffarena::Alloc<bf16> probs_bf16;
-    if (!hard_soft_next) probs_bf16 = ar0.alloc<bf16>((size_t)seq * V);
+    if (need_probs) probs_bf16 = ar0.alloc<bf16>((size_t)seq * V);
     GpuBuffer<int32_t> amax_dev(seq, q0), deno_dev(seq, q0);
     GpuBuffer<float>   ent_dev(seq, q0);
     std::vector<float> u(seq);
@@ -191,8 +218,21 @@ void DiffusionGemmaModel::decode_step(
     { DIFF_PROF(q0, "lm.softmax_sample");
       fused_logits_head(q0, logits_bf16.data(),
                         cfg_.text.final_logit_softcapping, 1.0f / temp,
-                        u_dev.data(), hard_soft_next ? nullptr : probs_bf16.data(),
+                        u_dev.data(), need_probs ? probs_bf16.data() : nullptr,
                         amax_dev.data(), ent_dev.data(), deno_dev.data(), seq, V); }
+
+    // TopK soft_next reads the same logits for its selection — extract before
+    // the logits buffer is released.
+    GpuBuffer<int32_t> topk_idx_dev;
+    GpuBuffer<float>   topk_w_dev;
+    if (sn.mode == SoftNextMode::TopK) {
+        topk_idx_dev = GpuBuffer<int32_t>((size_t)seq * sn.k, q0);
+        topk_w_dev   = GpuBuffer<float>((size_t)seq * sn.k, q0);
+        DIFF_PROF(q0, "lm.topk_select");
+        topk_soft_select(q0, logits_bf16.data(),
+                         cfg_.text.final_logit_softcapping, 1.0f / temp,
+                         sn.k, topk_idx_dev.data(), topk_w_dev.data(), seq, V);
+    }
     logits_bf16.reset();
 
     argmax.resize(seq); entropy.resize(seq); denoiser.resize(seq);
@@ -201,25 +241,41 @@ void DiffusionGemmaModel::decode_step(
       amax_dev.download(a.data(), seq); deno_dev.download(d.data(), seq);
       ent_dev.download(entropy.data(), seq);
       for (int i = 0; i < seq; ++i) { argmax[i] = a[i]; denoiser[i] = d[i]; } }
-    // soft_next = probs @ embed * embed_scale   (next-step signal).
+    // soft_next: next-step self-conditioning signal (embed_scale_ folded in).
     soft_next = GpuBuffer<bf16>((size_t)seq * H, q0);
     { DIFF_PROF(q0, "lm.soft_next");
-      if (hard_soft_next) {
-          // Gather the argmax token embedding (already includes embed_scale_).
+      switch (sn.mode) {
+      case SoftNextMode::Hard:
+          // Gather the argmax token embedding.
           if (!w_.embed_tokens_q8.empty())
               embedding_lookup_q8_0(q0, w_.embed_tokens_q8, amax_dev.data(),
                                     soft_next.data(), seq, H, embed_scale_);
           else
               embedding_lookup(q0, w_.embed_tokens.data(), amax_dev.data(),
                                soft_next.data(), seq, H, embed_scale_);
-      } else if (!w_.embed_tokens_q8.empty()) {
-          matmul_q8_0_nn(probs_bf16.data(), seq, V, w_.embed_tokens_q8, H,
-                         soft_next.data(), ctx0);
-      } else {
-          matmul_bf16_nn(probs_bf16.data(), seq, V, w_.embed_tokens.data(), H, soft_next.data(), ctx0);
-      }
-      probs_bf16.reset();
-      if (!hard_soft_next)
-          scale_inplace(q0, soft_next.data(), seq * H, embed_scale_); }
+          break;
+      case SoftNextMode::TopK:
+          // Top-k weighted embedding gather.
+          if (!w_.embed_tokens_q8.empty())
+              weighted_embed_gather_q8_0(q0, w_.embed_tokens_q8, topk_idx_dev.data(),
+                                         topk_w_dev.data(), soft_next.data(),
+                                         seq, sn.k, H, embed_scale_);
+          else
+              weighted_embed_gather(q0, w_.embed_tokens.data(), topk_idx_dev.data(),
+                                    topk_w_dev.data(), soft_next.data(),
+                                    seq, sn.k, H, embed_scale_);
+          break;
+      case SoftNextMode::Exact:
+          // soft_next = probs @ embed, then * embed_scale.
+          if (!w_.embed_tokens_q8.empty())
+              matmul_q8_0_nn(probs_bf16.data(), seq, V, w_.embed_tokens_q8, H,
+                             soft_next.data(), ctx0);
+          else
+              matmul_bf16_nn(probs_bf16.data(), seq, V, w_.embed_tokens.data(), H,
+                             soft_next.data(), ctx0);
+          probs_bf16.reset();
+          scale_inplace(q0, soft_next.data(), seq * H, embed_scale_);
+          break;
+      } }
     q0.wait();
 }

--- a/src/modeling/diffusion_gemma/model.cpp
+++ b/src/modeling/diffusion_gemma/model.cpp
@@ -24,11 +24,19 @@ static void transfer(sycl::queue& src_q, const bf16* src,
     dst_q.memcpy(dst, stage.data(), n * sizeof(bf16)).wait();
 }
 
-static bool q8_argmax_soft_next_enabled() {
+// Cheap self-conditioning signal.  The exact path materializes BF16 probs over
+// the whole vocab and forms soft_next = probs(seq,V) @ embed(V,H) — a vocab-wide
+// GEMM as expensive as the LM head itself.  The "hard" path instead gathers the
+// argmax token's embedding (seq,H), skipping both the probs buffer and the GEMM.
+// Works for Q8_0 and BF16 embedding tables.  DIFF_SOFT_NEXT=hard|argmax enables
+// it (DIFF_Q8_SOFT_NEXT kept for back-compat with the original Q8-only flag).
+static bool hard_soft_next_enabled() {
     static bool enabled = [] {
-        const char* env = std::getenv("DIFF_Q8_SOFT_NEXT");
-        return env && (!std::strcmp(env, "argmax") || !std::strcmp(env, "hard") ||
-                       !std::strcmp(env, "1") || !std::strcmp(env, "on"));
+        auto on = [](const char* env) {
+            return env && (!std::strcmp(env, "argmax") || !std::strcmp(env, "hard") ||
+                           !std::strcmp(env, "1") || !std::strcmp(env, "on"));
+        };
+        return on(std::getenv("DIFF_SOFT_NEXT")) || on(std::getenv("DIFF_Q8_SOFT_NEXT"));
     }();
     return enabled;
 }
@@ -172,9 +180,9 @@ void DiffusionGemmaModel::decode_step(
     // F1: softcap + temperature + softmax + argmax + entropy +
     // multinomial sample in one kernel. Only BF16 probabilities are
     // materialized for the self-conditioning matmul.
-    bool q8_argmax_soft_next = !w_.embed_tokens_q8.empty() && q8_argmax_soft_next_enabled();
+    bool hard_soft_next = hard_soft_next_enabled();
     diffarena::Alloc<bf16> probs_bf16;
-    if (!q8_argmax_soft_next) probs_bf16 = ar0.alloc<bf16>((size_t)seq * V);
+    if (!hard_soft_next) probs_bf16 = ar0.alloc<bf16>((size_t)seq * V);
     GpuBuffer<int32_t> amax_dev(seq, q0), deno_dev(seq, q0);
     GpuBuffer<float>   ent_dev(seq, q0);
     std::vector<float> u(seq);
@@ -183,7 +191,7 @@ void DiffusionGemmaModel::decode_step(
     { DIFF_PROF(q0, "lm.softmax_sample");
       fused_logits_head(q0, logits_bf16.data(),
                         cfg_.text.final_logit_softcapping, 1.0f / temp,
-                        u_dev.data(), q8_argmax_soft_next ? nullptr : probs_bf16.data(),
+                        u_dev.data(), hard_soft_next ? nullptr : probs_bf16.data(),
                         amax_dev.data(), ent_dev.data(), deno_dev.data(), seq, V); }
     logits_bf16.reset();
 
@@ -196,9 +204,14 @@ void DiffusionGemmaModel::decode_step(
     // soft_next = probs @ embed * embed_scale   (next-step signal).
     soft_next = GpuBuffer<bf16>((size_t)seq * H, q0);
     { DIFF_PROF(q0, "lm.soft_next");
-      if (q8_argmax_soft_next) {
-          embedding_lookup_q8_0(q0, w_.embed_tokens_q8, amax_dev.data(),
-                                soft_next.data(), seq, H, embed_scale_);
+      if (hard_soft_next) {
+          // Gather the argmax token embedding (already includes embed_scale_).
+          if (!w_.embed_tokens_q8.empty())
+              embedding_lookup_q8_0(q0, w_.embed_tokens_q8, amax_dev.data(),
+                                    soft_next.data(), seq, H, embed_scale_);
+          else
+              embedding_lookup(q0, w_.embed_tokens.data(), amax_dev.data(),
+                               soft_next.data(), seq, H, embed_scale_);
       } else if (!w_.embed_tokens_q8.empty()) {
           matmul_q8_0_nn(probs_bf16.data(), seq, V, w_.embed_tokens_q8, H,
                          soft_next.data(), ctx0);
@@ -206,7 +219,7 @@ void DiffusionGemmaModel::decode_step(
           matmul_bf16_nn(probs_bf16.data(), seq, V, w_.embed_tokens.data(), H, soft_next.data(), ctx0);
       }
       probs_bf16.reset();
-      if (!q8_argmax_soft_next)
+      if (!hard_soft_next)
           scale_inplace(q0, soft_next.data(), seq * H, embed_scale_); }
     q0.wait();
 }

--- a/src/modeling/diffusion_gemma/model.hpp
+++ b/src/modeling/diffusion_gemma/model.hpp
@@ -68,15 +68,19 @@ private:
     void encode_block(const std::vector<int>& ids, int past_len);
 
     // One denoising step: decode the canvas, produce per-position argmax /
-    // entropy / multinomial sample, and the self-conditioning signal for the
-    // next step (left in `soft_next`).
+    // entropy / multinomial sample, and (when `want_soft_next`) the
+    // self-conditioning signal for the next step (left in `soft_next`).  The
+    // final scheduled step has no successor, so its `soft_next` is pure waste —
+    // callers may pass want_soft_next=false to skip it (and, in exact mode, the
+    // vocab-wide probs@embed GEMM that produces it).
     void decode_step(const std::vector<int>& canvas_ids,
                      const bf16* soft_or_null, int enc_len, float temp,
                      std::vector<int>& argmax,
                      std::vector<float>& entropy,
                      std::vector<int>& denoiser,
                      GpuBuffer<bf16>& soft_next,
-                     std::mt19937& rng);
+                     std::mt19937& rng,
+                     bool want_soft_next = true);
 
     DiffConfig    cfg_;
     DiffPerfStats stats_;

--- a/src/modeling/diffusion_gemma/model.hpp
+++ b/src/modeling/diffusion_gemma/model.hpp
@@ -82,10 +82,44 @@ private:
                      std::mt19937& rng,
                      bool want_soft_next = true);
 
+    // Device-only denoiser forward (no host round-trip): embed+selfcond,
+    // decoder layers, final norm, LM head, fused_logits_head, and the
+    // self-conditioning (soft_next) build.  `ids` are the canvas tokens on the
+    // device; `u_dev` (seq floats) must already be filled with sampling
+    // variates.  Writes argmax / entropy / denoiser to the given device
+    // pointers (no D2H).  All heavyweight scratch is arena-scoped internally.
+    // On the device-resident denoising loop (default) this is called every
+    // step without a host sync; the in-order queue serializes it against the
+    // device sampler/stopping kernels that follow.
+    void decode_forward(const int32_t* ids, const bf16* soft_or_null,
+                        int enc_len, int seq, float temp, const float* u_dev,
+                        int32_t* argmax_dev, float* entropy_dev,
+                        int32_t* denoiser_dev, GpuBuffer<bf16>& soft_next,
+                        bool want_soft_next);
+
+    // Allocate (or grow) the persistent device buffers backing the
+    // device-resident denoising loop, sized for one canvas of `seq` tokens.
+    // Idempotent: no-ops when already large enough.
+    void ensure_device_buffers(int seq);
+
     DiffConfig    cfg_;
     DiffPerfStats stats_;
     int         split_layer_ = 0;
     float       embed_scale_ = 1.0f;
     DiffWeights w_;
     DiffKvCache enc_kv_;
+
+    // Persistent device buffers for the device-resident denoising loop (default
+    // path; the host-sampler path under DIFF_HOST_SAMPLER does not use these).
+    // Allocated once by ensure_device_buffers() and reused across blocks/steps.
+    GpuBuffer<int32_t> canvas_dev_;       // input canvas, renoised in place
+    GpuBuffer<int32_t> argmax_dev_;       // argmax of logits (committed output)
+    GpuBuffer<int32_t> denoiser_dev_;     // multinomial sample (accepted into canvas)
+    GpuBuffer<int32_t> prev_argmax_dev_;  // previous argmax (stability check)
+    GpuBuffer<float>   entropy_dev_;      // per-position entropy (nats)
+    GpuBuffer<float>   u_dev_;            // per-step sampling uniforms
+    GpuBuffer<float>   mean_dev_;         // scalar mean-entropy (device stopping)
+    GpuBuffer<int32_t> stop_dev_;         // scalar stop flag (device stopping)
+    GpuBuffer<char>    accepted_dev_;     // accept mask (callback payload)
+    int                dev_buf_seq_ = 0;  // current allocated canvas size
 };

--- a/src/modeling/diffusion_gemma/moe.cpp
+++ b/src/modeling/diffusion_gemma/moe.cpp
@@ -115,15 +115,19 @@ struct RouterRoutes {
     RouterRoutes& operator=(RouterRoutes&&) noexcept = default;
 };
 
+// Compute router softmax + top-k on the GPU instead of downloading the per-layer
+// scores to the host (a blocking copy that stalls the queue every MoE layer) and
+// sorting there.  Numerically equivalent to the host path; default on, opt out
+// with DIFF_ROUTER_GPU_TOPK=0.  Falls back to host routing when the device
+// per-expert-scale buffer is unavailable (see router()).
 static bool router_gpu_topk_enabled() {
     static bool enabled = [] {
         const char* env = std::getenv("DIFF_ROUTER_GPU_TOPK");
-        if (!env) return false;
+        if (!env) return true;
         if (!std::strcmp(env, "0") || !std::strcmp(env, "off") ||
             !std::strcmp(env, "false") || !std::strcmp(env, "no"))
             return false;
-        return !std::strcmp(env, "1") || !std::strcmp(env, "on") ||
-               !std::strcmp(env, "true") || !std::strcmp(env, "gpu");
+        return true;
     }();
     return enabled;
 }


### PR DESCRIPTION

```
notes below are from claude. Some of the ideas ended up working out well, others not so much.

The biggest thing though is that the hand rolled kernels to support scaling required in nvfp4.hpp.

GLM 5.2 did implementation work on my machine.
```















## Summary

Decode-hot-path efficiency work for DiffusionGemma. Each denoising step runs a *full bidirectional forward over the canvas* (`decode_step`, `model.cpp`) — it is not single-token AR decode — so per step the cost is dominated by matmuls (per-layer attention/MLP/MoE × L, plus two vocab-sized matmuls: the LM head and the `soft_next` self-conditioning GEMM) and by per-layer / per-step host sync. The work here attacks those, packaged as **env-gated A/B test cases** so an evaluator can sweep them in the hot path. Defaults are unchanged except the GPU router top-k flip (numerically equivalent to the prior behavior).

## Knobs added in this PR

| Env | Values | Default | What it changes |
|---|---|---|---|
| `DIFF_SOFT_NEXT` | `exact` \| `hard`/`argmax` \| `topk[:K]` | `exact` (unchanged) | how the next-step self-conditioning signal is built |
| `DIFF_ROUTER_GPU_TOPK` | `0`/`off`, else on | **on (flipped)** | MoE router softmax/top-k on GPU vs host |
| `DIFF_MOE_TAIL_CAP` | int `>0` | `64` (unchanged) | MoE cold-expert batched-GEMM tail capacity |
| `DIFF_SKIP_LAST_SOFT_NEXT` | set / unset | off (unchanged) | skip the unused `soft_next` on the final denoising step |
| `DIFF_PERSIST_XFER_STAGE` | set / unset | off (unchanged) | reuse the cross-GPU host staging buffer |

Observability: `DIFF_PROFILE=1` prints per-phase GPU timings (`lm.soft_next`, `lm.topk_select`, `ffn.*.router`, `ffn.*.experts_total`, `xfer`, …). `DIFF_MOE_STATS=1` dumps the expert-load distribution. `DIFF_Q8_SOFT_NEXT` is still parsed for back-compat.

## Changes & rationale

### 1. `soft_next` mode selector (`model.cpp`, `fusions/logits.hpp`, `q8_0.hpp`)
**Why:** the exact path forms `soft_next = probs(seq,V) @ embed(V,H)` — a vocab-wide GEMM ~as expensive as the LM head — *every* step, just to condition the next one. Modes trade fidelity for cost:
- **`hard`/`argmax`** — gather the argmax token embedding (`seq×H`). Cheapest; drops the probs buffer and the GEMM. Now BF16 **and** Q8_0 (was Q8-only).
- **`topk[:K]`** (default K=8) — accuracy-preserving middle ground. `topk_soft_select` finds the top-K tokens + renormalized softmax weights **without materializing probs** (`Z` cancels under top-k renorm, so only the global max is needed), then `weighted_embed_gather`/`_q8_0` builds `soft_next` at `k·H`/row. `top-1` equals the committed argmax by construction.

### 2. GPU router top-k default-on (`moe.cpp`)
**Why:** host routing downloads each layer's router scores and sorts on the CPU — a blocking copy that **stalls the queue on every MoE layer**. `router_topk_gpu` does identical math on-device. Safe: `per_expert_scale_dev` is populated unconditionally at load (`loader.cpp:918-920`) with host fallback; the repo's research notes already recommend it (`SYCL_VLLM_XPU_RESEARCH_REPORT.md:207`). Revert with `DIFF_ROUTER_GPU_TOPK=0`.

### 3. MoE tail-cap knob (`expert_parallel.cpp`)
**Why:** cold experts each occupy `T` padded rows; experts hotter than `T` spill to exact GEMMs. A fixed `T` over/under-pads depending on load. `DIFF_MOE_TAIL_CAP` exposes `T` (default 64) to tune the padding-vs-exact crossover against `DIFF_MOE_STATS`.

### 4. Skip the final-step `soft_next` (`model.cpp`, `model.hpp`, `generate.cpp`)
**Why:** the last scheduled step (`step==1`) has no successor to consume its self-conditioning signal — producing it is pure waste, and in `exact` mode it's a whole vocab GEMM. `decode_step` gains `want_soft_next` (default true); `generate` passes false on the last step under `DIFF_SKIP_LAST_SOFT_NEXT`. Correctness-neutral (committed tokens are argmax, computed regardless). Saves one `soft_next` per fully-denoised block.

### 5. Persistent cross-GPU staging (`model.cpp`)
**Why:** `transfer()` (host-staged cross-GPU hop, no P2P) allocates a fresh `std::vector` every call, and the split decode path hops twice per step. `DIFF_PERSIST_XFER_STAGE` reuses one grown-on-demand `thread_local` buffer — same bytes, no per-step malloc churn.

