### PR TITLE
diffusion_gemma: fix reference-implementation drift (KV window, adaptive stopping)

### DIFF
--- a/src/modeling/diffusion_gemma/attention.cpp
+++ b/src/modeling/diffusion_gemma/attention.cpp
@@ -1214,10 +1214,16 @@ void decoder_attention_forward(
     }
 
     // Bidirectional decoder attention: full layers see all encoder KV + canvas;
-    // sliding layers see the last sliding_window encoder positions + canvas.
+    // sliding layers see the last sliding_window-1 encoder positions + canvas.
+    // (The "-1" matches the reference implementation: the canvas's own first
+    // position would be the sliding_window'th slot of a real causal window, so
+    // only sliding_window-1 cached positions precede it. Widening this to
+    // sliding_window reads one extra, stale encoder token into every
+    // sliding-layer decode step, which is a small but real bidirectional-mask
+    // deviation from the reference model's default eager-cache behavior.)
     // Canvas K/V was staged at enc_len, so the right-sliced encoder tail and the
     // canvas rows are still one contiguous cache span.
-    int kv0 = lw.is_full ? 0 : std::max(0, enc_len - cfg.sliding_window);
+    int kv0 = lw.is_full ? 0 : std::max(0, enc_len - cfg.sliding_window + 1);
     const bf16* Kc = enc_kv.k.data() + (size_t)kv0 * row;
     const bf16* Vc = enc_kv.v.data() + (size_t)kv0 * row;
     auto attn = onednn_sdpa_decoder_enabled()

--- a/src/modeling/diffusion_gemma/attention.cpp
+++ b/src/modeling/diffusion_gemma/attention.cpp
@@ -1214,13 +1214,8 @@ void decoder_attention_forward(
     }
 
     // Bidirectional decoder attention: full layers see all encoder KV + canvas;
-    // sliding layers see the last sliding_window-1 encoder positions + canvas.
-    // (The "-1" matches the reference implementation: the canvas's own first
-    // position would be the sliding_window'th slot of a real causal window, so
-    // only sliding_window-1 cached positions precede it. Widening this to
-    // sliding_window reads one extra, stale encoder token into every
-    // sliding-layer decode step, which is a small but real bidirectional-mask
-    // deviation from the reference model's default eager-cache behavior.)
+    // sliding layers see the last sliding_window-1 encoder positions + canvas
+    // (the canvas's own first position fills the window's last slot).
     // Canvas K/V was staged at enc_len, so the right-sliced encoder tail and the
     // canvas rows are still one contiguous cache span.
     int kv0 = lw.is_full ? 0 : std::max(0, enc_len - cfg.sliding_window + 1);

--- a/src/modeling/diffusion_gemma/device_sampler.hpp
+++ b/src/modeling/diffusion_gemma/device_sampler.hpp
@@ -106,51 +106,55 @@ inline void entropy_bound_renoise(sycl::queue& q,
 
 // Stable-and-confident stopping, device-side.  Computes:
 //   mean      = mean(entropy)
-//   stable    = (stability_threshold == 0) || (!first_step && argmax == prev_argmax)
+//   stable    = (stability_threshold == 0) || all `stability_threshold` history
+//               slots equal the current argmax (i.e. stability_threshold+1
+//               consecutive identical canvases -- matches the reference's
+//               rolling-history criterion, not just the immediately-preceding
+//               canvas)
 //   confident = mean < confidence_threshold
 //   stop      = stable && confident
-// Writes mean -> *mean_out and stop -> *stop_out, then copies argmax -> prev_argmax
-// for the next step (so callers keep `prev_argmax` device-resident).
+// `history` is a (stability_threshold, seq) device buffer that the caller
+// resets to a sentinel (any value no real token id can take, e.g. -1) at the
+// start of each block; `slot` (0..stability_threshold-1, host-tracked and
+// incremented mod stability_threshold every step) selects which history row
+// this step's argmax rotates into.
+// Writes mean -> *mean_out and stop -> *stop_out.
 inline void stopping_check(sycl::queue& q,
-                           const int32_t* argmax, int32_t* prev_argmax,
+                           const int32_t* argmax, int32_t* history,
                            const float* entropy,
                            float* mean_out, int32_t* stop_out,
                            float confidence_threshold, int stability_threshold,
-                           bool first_step, int seq) {
+                           int slot, int seq) {
     q.submit([&](sycl::handler& h) {
         sycl::local_accessor<float, 1>  sent(sycl::range<1>(kMaxCanvas), h);
         sycl::local_accessor<int32_t, 1> sarg(sycl::range<1>(kMaxCanvas), h);
-        sycl::local_accessor<int32_t, 1> sprev(sycl::range<1>(kMaxCanvas), h);
         h.parallel_for(
             sycl::nd_range<1>(sycl::range<1>(kMaxCanvas), sycl::range<1>(kMaxCanvas)),
             [=](sycl::nd_item<1> it) {
                 int i = (int)it.get_local_id(0);
                 if (i < seq) {
-                    sent[i]  = entropy[i];
-                    sarg[i]  = argmax[i];
-                    sprev[i] = first_step ? 0 : prev_argmax[i];
+                    sent[i] = entropy[i];
+                    sarg[i] = argmax[i];
                 } else {
-                    sent[i] = 0.0f; sarg[i] = 0; sprev[i] = 0;
+                    sent[i] = 0.0f; sarg[i] = 0;
                 }
                 it.barrier(sycl::access::fence_space::local_space);
                 if (i == 0) {
                     float sum = 0.0f;
-                    int eq = 0;
-                    for (int j = 0; j < seq; ++j) {
-                        sum += sent[j];
-                        if (sarg[j] == sprev[j]) eq++;
-                    }
+                    for (int j = 0; j < seq; ++j) sum += sent[j];
                     float mean = sum / (float)seq;
-                    bool all_eq = (eq == seq);
-                    bool stable = (stability_threshold == 0)
-                                ? true
-                                : (!first_step && all_eq);
+
+                    bool stable = true;
+                    for (int hstep = 0; hstep < stability_threshold && stable; ++hstep)
+                        for (int j = 0; j < seq; ++j)
+                            if (history[hstep * seq + j] != sarg[j]) { stable = false; break; }
                     bool confident = mean < confidence_threshold;
                     *mean_out = mean;
                     *stop_out = (stable && confident) ? 1 : 0;
                 }
-                // copy argmax -> prev_argmax for the next step
-                if (i < seq) prev_argmax[i] = sarg[i];
+                // rotate this step's argmax into the history ring
+                if (stability_threshold > 0 && i < seq)
+                    history[slot * seq + i] = sarg[i];
             });
     });
 }

--- a/src/modeling/diffusion_gemma/generate.cpp
+++ b/src/modeling/diffusion_gemma/generate.cpp
@@ -109,9 +109,12 @@ std::vector<int> DiffusionGemmaModel::generate(
             auto& q0 = GpuEngine::get(0).queue;
             diffsamp::init_canvas_random(q0, canvas_dev_.data(), (uint64_t)seed,
                                          (uint32_t)blk, C, V);
+            if (cfg_.gen.stability_threshold > 0)
+                q0.fill(argmax_history_dev_.data(), (int32_t)-1,
+                       (size_t)cfg_.gen.stability_threshold * C);
+            int history_slot = 0;
             std::optional<GpuBuffer<bf16>> soft;
             GpuBuffer<bf16> soft_next_buf;
-            bool first_step = true;
             std::vector<float> entropy_h;
             std::vector<char>  accepted_h;
 
@@ -131,13 +134,14 @@ std::vector<int> DiffusionGemmaModel::generate(
                                                 entropy_dev_.data(), accepted_dev_.data(),
                                                 (uint64_t)seed, (uint32_t)blk, (uint32_t)step,
                                                 C, cfg_.gen.entropy_bound, V);
-                diffsamp::stopping_check(q0, argmax_dev_.data(), prev_argmax_dev_.data(),
+                diffsamp::stopping_check(q0, argmax_dev_.data(), argmax_history_dev_.data(),
                                          entropy_dev_.data(), mean_dev_.data(),
                                          stop_dev_.data(),
                                          cfg_.gen.confidence_threshold,
                                          cfg_.gen.stability_threshold,
-                                         first_step, C);
-                first_step = false;
+                                         history_slot, C);
+                if (cfg_.gen.stability_threshold > 0)
+                    history_slot = (history_slot + 1) % cfg_.gen.stability_threshold;
                 if (want_soft_next) soft.emplace(std::move(soft_next_buf));
 
                 stats_.decode_s += secs(td0, Clk::now());

--- a/src/modeling/diffusion_gemma/model.cpp
+++ b/src/modeling/diffusion_gemma/model.cpp
@@ -174,7 +174,8 @@ void DiffusionGemmaModel::ensure_device_buffers(int seq) {
     canvas_dev_      = GpuBuffer<int32_t>(seq, q0);
     argmax_dev_      = GpuBuffer<int32_t>(seq, q0);
     denoiser_dev_    = GpuBuffer<int32_t>(seq, q0);
-    prev_argmax_dev_ = GpuBuffer<int32_t>(seq, q0);
+    int hist_slots = std::max(1, cfg_.gen.stability_threshold);
+    argmax_history_dev_ = GpuBuffer<int32_t>((size_t)hist_slots * seq, q0);
     entropy_dev_     = GpuBuffer<float>(seq, q0);
     u_dev_           = GpuBuffer<float>(seq, q0);
     mean_dev_        = GpuBuffer<float>(1, q0);

--- a/src/modeling/diffusion_gemma/model.hpp
+++ b/src/modeling/diffusion_gemma/model.hpp
@@ -115,7 +115,7 @@ private:
     GpuBuffer<int32_t> canvas_dev_;       // input canvas, renoised in place
     GpuBuffer<int32_t> argmax_dev_;       // argmax of logits (committed output)
     GpuBuffer<int32_t> denoiser_dev_;     // multinomial sample (accepted into canvas)
-    GpuBuffer<int32_t> prev_argmax_dev_;  // previous argmax (stability check)
+    GpuBuffer<int32_t> argmax_history_dev_; // stability check: (stability_threshold, canvas) ring buffer
     GpuBuffer<float>   entropy_dev_;      // per-position entropy (nats)
     GpuBuffer<float>   u_dev_;            // per-step sampling uniforms
     GpuBuffer<float>   mean_dev_;         // scalar mean-entropy (device stopping)

--- a/src/modeling/diffusion_gemma/sampler.hpp
+++ b/src/modeling/diffusion_gemma/sampler.hpp
@@ -48,17 +48,24 @@ inline std::vector<int> entropy_bound_accept_renoise(
     return next;
 }
 
-// Stable-and-confident adaptive stopping (batch size 1).
+// Stable-and-confident adaptive stopping (batch size 1).  "Stable" requires
+// the current canvas to match *all* of the last `stability_threshold`
+// canvases (i.e. stability_threshold+1 consecutive identical canvases),
+// matching the reference's rolling-history criterion -- not just the single
+// immediately-preceding canvas.
 struct DiffStopping {
     int   stability_threshold;
     float confidence_threshold;
-    std::vector<int> prev_argmax;   // history of length 1 (threshold==1)
-    bool  have_prev = false;
+    std::vector<std::vector<int>> history;  // ring buffer, size == stability_threshold
+    int   next_slot = 0;
 
     DiffStopping(int stab, float conf)
         : stability_threshold(stab), confidence_threshold(conf) {}
 
-    void reset() { have_prev = false; prev_argmax.clear(); }
+    void reset() {
+        history.assign(std::max(stability_threshold, 0), std::vector<int>());
+        next_slot = 0;
+    }
 
     // Returns true when the canvas is both stable and confident.
     bool update(const std::vector<int>& argmax, const std::vector<float>& entropy) {
@@ -66,9 +73,11 @@ struct DiffStopping {
         if (stability_threshold == 0) {
             stable = true;
         } else {
-            stable = have_prev && (prev_argmax == argmax);
-            prev_argmax = argmax;
-            have_prev = true;
+            stable = true;
+            for (auto& h : history)
+                if (h != argmax) { stable = false; break; }
+            history[next_slot] = argmax;
+            next_slot = (next_slot + 1) % stability_threshold;
         }
         double mean = 0.0;
         for (float e : entropy) mean += e;


### PR DESCRIPTION
## Summary
- **Sliding-window KV span off-by-one** (`attention.cpp`): the decoder's cross-attention into the encoder KV cache kept `sliding_window` cached positions for sliding-attention layers once the cache exceeds the window. The reference (`transformers`' `DiffusionGemmaDecoderModel.create_diffusion_decoder_attention_mask`, default eager/`DynamicCache` path) keeps `sliding_window - 1` — the canvas's own first position occupies the window's last slot. Fixed by slicing at `enc_len - sliding_window + 1`.
- **Adaptive stopping ignored `stability_threshold`** (`sampler.hpp`, `device_sampler.hpp`, `model.{hpp,cpp}`, `generate.cpp`): both the host-sampler `DiffStopping` and the default device-resident `stopping_check` kernel only ever compared the current canvas against the single immediately-preceding one. The reference (`StableAndConfidentStoppingCriteria`) requires the current canvas to match a rolling history of `stability_threshold` prior canvases before declaring stability. Replaced the single `prev_argmax` slot with a small history ring (host: `std::vector<std::vector<int>>`; device: a `(stability_threshold, canvas)` GPU ring buffer rotated via a host-tracked slot index) on both the host-sampler and default device-resident paths.

Both were found by reading the reference `transformers` `diffusion_gemma` implementation side-by-side with `src/modeling/diffusion_gemma/`. Both are dormant at the model's shipped defaults (long-enough prompts trigger the first; `stability_threshold=1` masks the second, since a 1-step and N-step history coincide there), but real for other configs / longer contexts.

## Test plan
- [ ] Could not build/run locally in this environment (no SYCL/oneDNN toolchain or GPU available) — needs a build + generation smoke test on real hardware, ideally with `stability_threshold > 1` and a prompt longer than `sliding_window` to exercise both fixes.
- [x] Both changes reviewed by hand against the reference implementation's mask-construction and stopping-criteria logic.
