### PR TITLE
Fix: Support INT4-AWQ memory estimation with nested config parsing

### DIFF
--- a/src/common/gpu/placement.cpp
+++ b/src/common/gpu/placement.cpp
@@ -9,11 +9,21 @@ namespace {
 
 static size_t bf16_bytes(size_t elements) { return 2 * elements; }
 
-static size_t linear_bytes(size_t out_features, size_t in_features, bool nvfp4) {
-    if (!nvfp4) return bf16_bytes(out_features * in_features);
-    size_t packed = out_features * ((in_features + 1) / 2);
-    size_t scales = out_features * ((in_features + 15) / 16);
-    return packed + scales + 2 * sizeof(float);
+static size_t int4_bytes(size_t out_features, size_t in_features, int group_size) {
+    size_t elements = (size_t)out_features * in_features;
+    size_t packed = elements / 2;
+    size_t scales = (elements / group_size) * 2;
+    return packed + scales;
+}
+
+static size_t linear_bytes(size_t out_features, size_t in_features, bool nvfp4, int int4_group_size = 0) {
+    if (int4_group_size > 0) return int4_bytes(out_features, in_features, int4_group_size);
+    if (nvfp4) {
+        size_t packed = out_features * ((in_features + 1) / 2);
+        size_t scales = out_features * ((in_features + 15) / 16);
+        return packed + scales + 2 * sizeof(float);
+    }
+    return bf16_bytes(out_features * in_features);
 }
 
 static size_t attention_bytes(const DiffTextConfig& t, bool full) {
@@ -21,24 +31,27 @@ static size_t attention_bytes(const DiffTextConfig& t, bool full) {
     size_t attn;
     if (full) {
         size_t hd = t.global_head_dim;
-        attn = (size_t)t.num_attn_heads * hd * H * 2 + (size_t)t.num_global_kv_heads * hd * H;
+        attn = (size_t)(t.num_attn_heads + t.num_global_kv_heads) * hd * H * 2;
     } else {
         size_t hd = t.head_dim;
-        attn = (size_t)t.num_attn_heads * hd * H * 2 + (size_t)t.num_kv_heads * hd * H * 2;
+        attn = (size_t)(t.num_attn_heads + t.num_kv_heads) * hd * H * 2;
     }
+    if (t.int4_group_size > 0) return attn / 2 + (attn / t.int4_group_size) * 2;
     return bf16_bytes(attn);
 }
 
 static size_t dense_mlp_bytes(const DiffTextConfig& t, bool nvfp4) {
     size_t H = t.hidden_size;
     size_t I = t.intermediate_size;
-    return 2 * linear_bytes(I, H, nvfp4) + linear_bytes(H, I, nvfp4);
+    int g = t.int4_group_size;
+    return 2 * linear_bytes(I, H, nvfp4, g) + linear_bytes(H, I, nvfp4, g);
 }
 
 static size_t one_expert_bytes(const DiffTextConfig& t, bool nvfp4) {
     size_t H = t.hidden_size;
     size_t I = t.moe_intermediate_size;
-    return 2 * linear_bytes(I, H, nvfp4) + linear_bytes(H, I, nvfp4);
+    int g = t.int4_group_size;
+    return 2 * linear_bytes(I, H, nvfp4, g) + linear_bytes(H, I, nvfp4, g);
 }
 
 static size_t layer_bytes(const DiffTextConfig& t, bool full, bool nvfp4) {

--- a/src/modeling/diffusion_gemma/config.hpp
+++ b/src/modeling/diffusion_gemma/config.hpp
@@ -81,7 +81,18 @@ struct DiffConfig {
         if (j.contains("quantization_config") && j.at("quantization_config").is_object()) {
             auto& qc = j.at("quantization_config");
             cfg.quantization_format = qc.value("format", std::string());
+            // Try direct group_size first, then nested config_groups.group_0.weights.group_size
             cfg.text.int4_group_size = qc.value("group_size", 0);
+            if (cfg.text.int4_group_size == 0 && qc.contains("config_groups") && qc.at("config_groups").is_object()) {
+                auto& cg = qc.at("config_groups");
+                if (cg.contains("group_0") && cg.at("group_0").is_object()) {
+                    auto& g0 = cg.at("group_0");
+                    if (g0.contains("weights") && g0.at("weights").is_object()) {
+                        auto& w = g0.at("weights");
+                        cfg.text.int4_group_size = w.value("group_size", 0);
+                    }
+                }
+            }
         }
 
         cfg.canvas_length  = j.value("canvas_length", 256);

--- a/src/modeling/diffusion_gemma/config.hpp
+++ b/src/modeling/diffusion_gemma/config.hpp
@@ -19,6 +19,7 @@ struct DiffTextConfig {
     int head_dim = 0, global_head_dim = 0;
     int num_experts = 0, top_k_experts = 0, moe_intermediate_size = 0;
     int sliding_window = 0;
+    int int4_group_size = 0;  // INT4-AWQ quantization group size (0 = not quantized)
     float rms_norm_eps = 1e-6f, final_logit_softcapping = 30.0f;
     int bos_token_id = 2, pad_token_id = 0;
     std::vector<int> eos_token_ids;
@@ -77,8 +78,11 @@ struct DiffConfig {
         cfg.model_type = j.at("model_type").get<std::string>();
         if (cfg.model_type != "diffusion_gemma")
             throw std::runtime_error("Expected model_type=diffusion_gemma, got " + cfg.model_type);
-        if (j.contains("quantization_config") && j.at("quantization_config").is_object())
-            cfg.quantization_format = j.at("quantization_config").value("format", std::string());
+        if (j.contains("quantization_config") && j.at("quantization_config").is_object()) {
+            auto& qc = j.at("quantization_config");
+            cfg.quantization_format = qc.value("format", std::string());
+            cfg.text.int4_group_size = qc.value("group_size", 0);
+        }
 
         cfg.canvas_length  = j.value("canvas_length", 256);
         cfg.image_token_id = j.value("image_token_id", 258880);


### PR DESCRIPTION
## Description
This PR fixes an issue in memory estimation for INT4-AWQ quantized models (specifically DiffusionGemma 26B-A4B). Previously, the code looked for group_size at the top level of quantization_config. However, for these models, the value is nested within config_groups.group_0.weights.group_size.

As a result, the system defaulted to 0, leading to incorrect memory allocation calculations during placement.

## Changes
- src/modeling/diffusion_gemma/config.hpp:
    - Added int4_group_size field to the DiffTextConfig struct.
    - Updated the configuration parser to resolve group_size. It now attempts to read it from the top level first, and falls back to the nested path config_groups.group_0.weights.group_size if the top-level is missing.

- src/common/gpu/placement.cpp:
    - Updated linear_bytes, attention_bytes, dense_mlp_bytes, and one_expert_bytes to utilize int4_group_size.
    - Implemented logic to account for packed weights and group scales when INT4 quantization is detected.

## Verification
Verified using arcaine_server. The memory distribution is now displayed correctly:

### Before
<img width="666" height="126" alt="image" src="https://github.com/user-attachments/assets/97a63df5-7296-4c56-bbc3-29fe98d79c79" />

### Now
GPU0: 8.32 GB (layer/local 1.89 GB + expert-shard 6.42 GB)
GPU1: 7.00 GB (layer/local 0.57 GB + expert-shard 6.42 GB)

## Command used for testing:
```
./build/arcaine_server --model /home/arc/Arcaine/models/cyankiwi/diffusiongemma-26B-A4B-it-AWQ-INT4/ \
  --served-model-name diffusiongemma-26B-A4B-it-AWQ-INT4/ \
  --host 0.0.0.0 \
  --port 9999 \
  --max-tokens 16000 \
  --max-seq 32000
  ```


## Testing Environment:
OS: Ubuntu 26.04 (7.1.4-070104-generic)
Toolkit: OneAPI 2026.1
2x Intel Arc A770

## Note
Please ensure this is tested on **BMG** to verify compatibility.

_PS: The PR description was prepared using diffusiongemma-26B-A4B-it-AWQ-INT4 via Arcaine server_

