### PR TITLE
feat: asymmetric expert sharding via --experts ranges:N,N,...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ set(ARCAINE_SYCL_TARGETS "" CACHE STRING
     "Optional DPC++ SYCL AOT target list, e.g. intel_gpu_bmg_g31")
 if(ARCAINE_SYCL_TARGETS)
     set(ARCAINE_SYCL_TARGET_FLAG "-fsycl-targets=${ARCAINE_SYCL_TARGETS}")
+    # AOT gen targets use the spir64_gen triple; icpx cannot deduce the triple
+    # for -Xspirv-translator when explicit -fsycl-targets are given.
+    set(ARCAINE_SPIRV_TRANSLATOR_FLAG "-Xspirv-translator=spir64_gen")
+else()
+    set(ARCAINE_SPIRV_TRANSLATOR_FLAG "-Xspirv-translator")
 endif()
 
 # Build with the Intel DPC++/SYCL compiler. Configure with:
@@ -104,7 +109,7 @@ target_compile_options(gemma4 PRIVATE -fsycl -fno-sycl-id-queries-fit-in-int -O2
 target_link_options(gemma4   PRIVATE -fsycl ${ARCAINE_SYCL_TARGET_FLAG})
 # ARCH_SRCS now pulls qwen3_5_moe (NVFP4 loader) + common/quant_loader.cpp, both
 # of which include nvfp4.hpp -> __spirv_SubgroupMatrixMultiplyAccumulateINTEL.
-target_link_options(gemma4 PRIVATE -Xspirv-translator -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
+target_link_options(gemma4 PRIVATE ${ARCAINE_SPIRV_TRANSLATOR_FLAG} -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
 target_link_libraries(gemma4 PRIVATE DNNL::dnnl soxr onnxruntime)
 set_target_properties(gemma4 PROPERTIES
     BUILD_RPATH "${ORT_DIR}/lib"
@@ -130,7 +135,7 @@ add_executable(arcaine_mbench src/arcaine_mbench.cpp ${COMMON_SRCS} ${ARCH_SRCS}
 target_compile_options(arcaine_mbench PRIVATE -fsycl -fno-sycl-id-queries-fit-in-int -O2 ${ARCAINE_SYCL_TARGET_FLAG})
 target_link_options(arcaine_mbench   PRIVATE -fsycl ${ARCAINE_SYCL_TARGET_FLAG})
 # See gemma4: ARCH_SRCS / COMMON_SRCS include nvfp4.hpp-bearing loader TUs.
-target_link_options(arcaine_mbench PRIVATE -Xspirv-translator -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
+target_link_options(arcaine_mbench PRIVATE ${ARCAINE_SPIRV_TRANSLATOR_FLAG} -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
 target_link_libraries(arcaine_mbench PRIVATE DNNL::dnnl soxr onnxruntime)
 set_target_properties(arcaine_mbench PROPERTIES
     BUILD_RPATH "${ORT_DIR}/lib"
@@ -161,7 +166,7 @@ set(DIFFUSION_SRCS
 add_executable(diffusion_gemma src/diffusion_main.cpp ${DIFFUSION_SRCS})
 target_compile_options(diffusion_gemma PRIVATE -fsycl -fno-sycl-id-queries-fit-in-int -O2 ${ARCAINE_SYCL_TARGET_FLAG})
 target_link_options(diffusion_gemma   PRIVATE -fsycl ${ARCAINE_SYCL_TARGET_FLAG})
-target_link_options(diffusion_gemma PRIVATE -Xspirv-translator -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
+target_link_options(diffusion_gemma PRIVATE ${ARCAINE_SPIRV_TRANSLATOR_FLAG} -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
 
 # OpenAI-compatible HTTP API server. Single binary serving every registered
 # architecture: dispatches by config.json::model_type at startup.
@@ -182,13 +187,13 @@ add_executable(arcaine_server
     src/register_builtins.cpp)
 target_compile_options(arcaine_server PRIVATE -fsycl -fno-sycl-id-queries-fit-in-int -O2 ${ARCAINE_SYCL_TARGET_FLAG})
 target_link_options(arcaine_server   PRIVATE -fsycl ${ARCAINE_SYCL_TARGET_FLAG})
-target_link_options(arcaine_server PRIVATE -Xspirv-translator -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
+target_link_options(arcaine_server PRIVATE ${ARCAINE_SPIRV_TRANSLATOR_FLAG} -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
 
 # llama-bench style throughput benchmark (loads once, sweeps expert kernels).
 add_executable(diffusion_bench src/diffusion_bench.cpp ${DIFFUSION_SRCS})
 target_compile_options(diffusion_bench PRIVATE -fsycl -fno-sycl-id-queries-fit-in-int -O2 ${ARCAINE_SYCL_TARGET_FLAG})
 target_link_options(diffusion_bench   PRIVATE -fsycl ${ARCAINE_SYCL_TARGET_FLAG})
-target_link_options(diffusion_bench PRIVATE -Xspirv-translator -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
+target_link_options(diffusion_bench PRIVATE ${ARCAINE_SPIRV_TRANSLATOR_FLAG} -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
 target_link_libraries(diffusion_bench PRIVATE DNNL::dnnl)
 target_link_libraries(diffusion_gemma PRIVATE DNNL::dnnl)
 target_link_libraries(arcaine_server PRIVATE DNNL::dnnl soxr onnxruntime)
@@ -212,6 +217,7 @@ set(KBENCH_SRCS
     src/bench/qwen35_delta_decode_fusion_bench.cpp
     src/bench/nvfp4_roofline_bench.cpp
     src/bench/diffusion_int4_fusion_bench.cpp
+    src/bench/diffusion_int4_grouped_moe_bench.cpp
     # qwen35_nvfp4_mlp_bench loads a real NVFP4 layer:
     src/common/io/quant_loader.cpp
     src/common/gpu/nvfp4_session.cpp)
@@ -220,7 +226,6 @@ target_compile_options(arcaine_kbench PRIVATE
     -fsycl -fno-sycl-id-queries-fit-in-int -O2 ${ARCAINE_SYCL_TARGET_FLAG})
 target_link_options(arcaine_kbench PRIVATE -fsycl ${ARCAINE_SYCL_TARGET_FLAG})
 target_link_options(arcaine_kbench PRIVATE
-    -Xspirv-translator -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
+    ${ARCAINE_SPIRV_TRANSLATOR_FLAG} -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
 target_link_libraries(arcaine_kbench PRIVATE DNNL::dnnl)
-
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       dockerfile: .devops/Dockerfile
       args:
         ONEAPI_VERSION: 2025.3.3-0-devel-ubuntu24.04
-        ONEDNN_VERSION: v3.12
+        ONEDNN_VERSION: main
         INSTALL_RUST: "1"
     image: arcaine:latest
 

--- a/scripts/benchmark_diffusion_int4_grouped_moe.sh
+++ b/scripts/benchmark_diffusion_int4_grouped_moe.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir="${BUILD_DIR:-/workspace/build}"
+iterations="${ITERATIONS:-10}"
+local_experts="${LOCAL_EXPERTS:-44}"
+first_expert="${FIRST_EXPERT:-0}"
+seq_lengths="${SEQ_LENGTHS:-256}"
+
+cmake --build "${build_dir}" --target arcaine_kbench -j"$(nproc)"
+
+IFS=',' read -ra seq_values <<< "${seq_lengths}"
+for seq in "${seq_values[@]}"; do
+  DIFF_INT4_GROUPED_DPAS_MOE=1 \
+  "${build_dir}/arcaine_kbench" diffusion-int4-grouped-moe \
+    --experts "${local_experts}" \
+    --first "${first_expert}" \
+    --seq "${seq}" \
+    --iterations "${iterations}"
+done

--- a/src/arcaine_server.cpp
+++ b/src/arcaine_server.cpp
@@ -1195,7 +1195,10 @@ void apply_experts_spec(const std::string& value, DiffPlacementOptions& placemen
         placement.expert_mode = DiffExpertPlacementMode::Shard;
     } else if (value == "local") {
         throw std::runtime_error("--experts local was renamed; use --experts layer-owner");
-    } else if (value == "replicate" || value.rfind("ranges:", 0) == 0 || value.rfind("gpus:", 0) == 0) {
+    } else if (value.rfind("ranges:", 0) == 0) {
+        placement.expert_mode = DiffExpertPlacementMode::Shard;
+        placement.expert_counts = parse_expert_ranges(value.substr(7));
+    } else if (value == "replicate" || value.rfind("gpus:", 0) == 0) {
         throw std::runtime_error("--experts value '" + value + "' is not implemented by this runtime yet");
     } else {
         throw std::runtime_error("--experts must be one of: auto, layer-owner, replicate, shard, ranges:N,N,..., gpus:N");

--- a/src/bench/diffusion_int4_grouped_moe_bench.cpp
+++ b/src/bench/diffusion_int4_grouped_moe_bench.cpp
@@ -1,0 +1,337 @@
+// Focused DiffusionGemma INT4-AWQ grouped-MoE benchmark.
+//
+// This exercises DiffusionGemma's top-8 expert path at a selected context
+// length. The baseline is the current per-active-expert oneDNN s4 sequence;
+// the candidate is the device-routed grouped DPAS sequence. It deliberately
+// does not run end-to-end inference.
+
+#include "common/bench/registry.hpp"
+#include "common/bench/util.hpp"
+#include "common/gpu/buffer.hpp"
+#include "common/gpu/engine.hpp"
+#include "common/gpu/int4.hpp"
+#include "common/gpu/int4_grouped_moe.hpp"
+#include "common/kernels/elementwise.hpp"
+#include "modeling/diffusion_gemma/fusions/int4_awq.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using arcaine::bench::elapsed_ms;
+
+namespace {
+
+constexpr int kDefaultSeq = 256;
+constexpr int kTopK = 8;
+constexpr int kGlobalExperts = 128;
+constexpr int kHidden = 2816;
+constexpr int kInter = 704;
+constexpr int kGroup = 32;
+constexpr int kTail = 64;
+
+int round_up(int v, int m) { return (v + m - 1) / m * m; }
+
+bf16 activation_pattern(size_t i) {
+    int v = (int)((i * 29 + 17) % 101) - 50;
+    return float_to_bf16((float)v * 0.002f);
+}
+
+Int4Linear make_weight(GpuEngine& ctx, int K, int N, int seed) {
+    Int4Linear w;
+    w.in_features = K;
+    w.out_features = N;
+    w.group_size = kGroup;
+    const size_t packed_count = (size_t)N * K / 2;
+    const size_t scale_count = (size_t)(K / kGroup) * N;
+    std::vector<uint8_t> packed(packed_count);
+    std::vector<bf16> scale(scale_count);
+    for (size_t i = 0; i < packed_count; ++i) {
+        int lo = (int)((i * 13 + seed) % 7) - 3;
+        int hi = (int)((i * 19 + seed + 5) % 7) - 3;
+        packed[i] = (uint8_t)((lo & 0xf) | ((hi & 0xf) << 4));
+    }
+    for (size_t i = 0; i < scale_count; ++i)
+        scale[i] = float_to_bf16(0.003f + 0.00025f * (float)((i + seed) % 5));
+    w.weight_packed = GpuBuffer<uint8_t>(packed_count, ctx.queue);
+    w.weight_scale = GpuBuffer<bf16>(scale_count, ctx.queue);
+    w.weight_packed.upload(packed.data(), packed.size());
+    w.weight_scale.upload(scale.data(), scale.size());
+    return w;
+}
+
+void combine_baseline(sycl::queue& q, const bf16* expert_out,
+                      const int32_t* slot, const float* weight,
+                      int seq, int top_k, int H, bf16* out) {
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::range<2>((size_t)seq, (size_t)H),
+                       [=](sycl::id<2> id) {
+            int token = (int)id[0], dim = (int)id[1];
+            float acc = 0.0f;
+            for (int k = 0; k < top_k; ++k) {
+                int pair = token * top_k + k;
+                int row = slot[pair];
+                if (row >= 0)
+                    acc += weight[pair] *
+                           bf16_to_float(expert_out[(size_t)row * H + dim]);
+            }
+            out[(size_t)token * H + dim] = float_to_bf16(acc);
+        });
+    });
+}
+
+struct ErrorStats {
+    float max_abs = 0.0f;
+    double rms = 0.0;
+    double cosine = 0.0;
+    size_t bit_mismatches = 0;
+};
+
+ErrorStats compare(const std::vector<bf16>& a, const std::vector<bf16>& b) {
+    if (a.size() != b.size()) throw std::runtime_error("comparison size mismatch");
+    ErrorStats s;
+    double err2 = 0.0, aa = 0.0, bb = 0.0, ab = 0.0;
+    for (size_t i = 0; i < a.size(); ++i) {
+        float av = bf16_to_float(a[i]);
+        float bv = bf16_to_float(b[i]);
+        float d = av - bv;
+        if (a[i] != b[i]) ++s.bit_mismatches;
+        s.max_abs = std::max(s.max_abs, std::abs(d));
+        err2 += (double)d * d;
+        aa += (double)av * av;
+        bb += (double)bv * bv;
+        ab += (double)av * bv;
+    }
+    s.rms = std::sqrt(err2 / (double)a.size());
+    s.cosine = ab / std::sqrt(std::max(aa * bb, 1e-30));
+    return s;
+}
+
+int run(int argc, char** argv) {
+    int local_experts = 44;
+    int first_expert = 0;
+    int iterations = 10;
+    int seq = kDefaultSeq;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--experts" && i + 1 < argc) local_experts = std::atoi(argv[++i]);
+        else if (arg == "--first" && i + 1 < argc) first_expert = std::atoi(argv[++i]);
+        else if (arg == "--iterations" && i + 1 < argc) iterations = std::atoi(argv[++i]);
+        else if (arg == "--seq" && i + 1 < argc) seq = std::atoi(argv[++i]);
+        else if (arg == "--help" || arg == "-h") {
+            std::printf("Usage: %s [--experts N] [--first N] "
+                        "[--seq N] [--iterations N]\n", argv[0]);
+            return 0;
+        } else {
+            std::fprintf(stderr, "unknown argument: %s\n", arg.c_str());
+            return 2;
+        }
+    }
+    if (!diff_int4_grouped_dpas_moe_enabled()) {
+        std::fprintf(stderr, "Set DIFF_INT4_GROUPED_DPAS_MOE=1 to benchmark the candidate path.\n");
+        return 2;
+    }
+    if (local_experts <= 0 || first_expert < 0 ||
+        first_expert + local_experts > kGlobalExperts || iterations <= 0 || seq <= 0)
+        throw std::runtime_error("invalid expert range, context length, or iteration count");
+
+    GpuEngine& ctx = GpuEngine::get(0);
+    auto& q = ctx.queue;
+    const int pairs = seq * kTopK;
+    const int max_active = std::min(local_experts, pairs);
+    std::printf("[device] %s | range=[%d,%d) | iterations=%d | slice=%d\n",
+                q.get_device().get_info<sycl::info::device::name>().c_str(),
+                first_expert, first_expert + local_experts, iterations,
+                diff_int4_grouped_dpas_expert_slice());
+    if (!diff_int4_grouped_dpas_device_supported(q.get_device())) {
+        std::printf("[unsupported] grouped BF16 DPAS requires Xe2/Battlemage; "
+                    "this device uses the oneDNN INT4 path.\n");
+        return 0;
+    }
+
+    std::vector<bf16> input_h((size_t)seq * kHidden);
+    std::vector<int32_t> idx_h(pairs), slot_h(pairs, -1);
+    std::vector<float> weight_h(pairs, 1.0f / (float)kTopK);
+    for (size_t i = 0; i < input_h.size(); ++i) input_h[i] = activation_pattern(i);
+    for (int t = 0; t < seq; ++t)
+        for (int k = 0; k < kTopK; ++k)
+            idx_h[t * kTopK + k] = (t * 13 + k * 17) % kGlobalExperts;
+
+    std::vector<int> counts(local_experts, 0), cursor(local_experts, 0);
+    for (int pair = 0; pair < pairs; ++pair) {
+        int e = idx_h[pair] - first_expert;
+        if (e >= 0 && e < local_experts) ++counts[e];
+    }
+    const int tail = std::min(kTail, round_up(seq, 8));
+    std::vector<int> base(local_experts), bucket_cap(local_experts, tail);
+    int total_rows = local_experts * tail;
+    for (int e = 0; e < local_experts; ++e) {
+        if (counts[e] > tail) {
+            base[e] = total_rows;
+            bucket_cap[e] = round_up(counts[e], 32);
+            total_rows += bucket_cap[e];
+        } else {
+            base[e] = e * tail;
+        }
+    }
+    for (int pair = 0; pair < pairs; ++pair) {
+        int e = idx_h[pair] - first_expert;
+        if (e >= 0 && e < local_experts) slot_h[pair] = base[e] + cursor[e]++;
+    }
+    GpuBuffer<bf16> input(input_h.size(), q);
+    GpuBuffer<int32_t> idx(pairs, q), slot(pairs, q);
+    GpuBuffer<float> weight(pairs, q);
+    input.upload(input_h.data(), input_h.size());
+    idx.upload(idx_h.data(), idx_h.size());
+    slot.upload(slot_h.data(), slot_h.size());
+    weight.upload(weight_h.data(), weight_h.size());
+
+    std::vector<Int4Linear> gate(local_experts), down(local_experts);
+    std::vector<const uint8_t*> gate_w_h(local_experts), down_w_h(local_experts);
+    std::vector<const bf16*> gate_s_h(local_experts), down_s_h(local_experts);
+    for (int e = 0; e < local_experts; ++e) {
+        gate[e] = make_weight(ctx, kHidden, 2 * kInter, 31 + e);
+        down[e] = make_weight(ctx, kInter, kHidden, 197 + e);
+        gate_w_h[e] = gate[e].weight_packed.data();
+        gate_s_h[e] = gate[e].weight_scale.data();
+        down_w_h[e] = down[e].weight_packed.data();
+        down_s_h[e] = down[e].weight_scale.data();
+    }
+    GpuBuffer<const uint8_t*> gate_w(local_experts, q), down_w(local_experts, q);
+    GpuBuffer<const bf16*> gate_s(local_experts, q), down_s(local_experts, q);
+    gate_w.upload(gate_w_h.data(), gate_w_h.size());
+    gate_s.upload(gate_s_h.data(), gate_s_h.size());
+    down_w.upload(down_w_h.data(), down_w_h.size());
+    down_s.upload(down_s_h.data(), down_s_h.size());
+
+    GpuBuffer<bf16> xe((size_t)total_rows * kHidden, q);
+    GpuBuffer<bf16> gu((size_t)total_rows * 2 * kInter, q);
+    GpuBuffer<bf16> act((size_t)total_rows * kInter, q);
+    GpuBuffer<bf16> ye((size_t)total_rows * kHidden, q);
+    GpuBuffer<bf16> baseline_out((size_t)seq * kHidden, q);
+
+    GpuBuffer<int32_t> offsets((size_t)local_experts + 1, q), tokens(pairs, q);
+    GpuBuffer<int32_t> active_experts(max_active, q), active_count(1, q);
+    GpuBuffer<bf16> grouped_act((size_t)pairs * kInter, q);
+    GpuBuffer<bf16> pair_out((size_t)pairs * kHidden, q);
+    GpuBuffer<bf16> grouped_out((size_t)seq * kHidden, q);
+
+    auto baseline = [&] {
+        q.memset(xe.data(), 0, xe.count() * sizeof(bf16));
+        const int32_t* slot_ptr = slot.data();
+        const bf16* input_ptr = input.data();
+        bf16* xe_ptr = xe.data();
+        q.submit([&](sycl::handler& h) {
+            h.parallel_for(sycl::range<2>((size_t)pairs, (size_t)kHidden),
+                           [=](sycl::id<2> id) {
+                int pair = (int)id[0], dim = (int)id[1];
+                int row = slot_ptr[pair];
+                if (row >= 0)
+                    xe_ptr[(size_t)row * kHidden + dim] =
+                        input_ptr[(size_t)(pair / kTopK) * kHidden + dim];
+            });
+        });
+        for (int e = 0; e < local_experts; ++e) {
+            if (counts[e] == 0) continue;
+            int m = std::min(bucket_cap[e], round_up(counts[e], 32));
+            matmul_int4(xe.data() + (size_t)base[e] * kHidden,
+                        m, kHidden, gate[e],
+                        gu.data() + (size_t)base[e] * 2 * kInter, ctx);
+        }
+        geglu_strided(q, gu.data(), act.data(), total_rows, kInter);
+        for (int e = 0; e < local_experts; ++e) {
+            if (counts[e] == 0) continue;
+            int m = std::min(bucket_cap[e], round_up(counts[e], 32));
+            matmul_int4(act.data() + (size_t)base[e] * kInter,
+                        m, kInter, down[e],
+                        ye.data() + (size_t)base[e] * kHidden, ctx);
+        }
+        combine_baseline(q, ye.data(), slot.data(), weight.data(),
+                         seq, kTopK, kHidden, baseline_out.data());
+    };
+
+    auto grouped = [&] {
+        int4_grouped_moe_build_routes(
+            q, idx.data(), first_expert, local_experts, pairs,
+            offsets.data(), tokens.data(), active_experts.data(), active_count.data());
+        matmul_int4_grouped_dpas_gateup_geglu(
+            q, input.data(), kHidden, gate_w.data(), gate_s.data(),
+            offsets.data(), tokens.data(), local_experts, pairs, kTopK,
+            kInter, kGroup, grouped_act.data(), active_experts.data(),
+            active_count.data(), max_active);
+        matmul_int4_grouped_dpas_down(
+            q, grouped_act.data(), kInter, down_w.data(), down_s.data(),
+            offsets.data(), tokens.data(), local_experts, pairs, kHidden,
+            kGroup, pair_out.data(), active_experts.data(),
+            active_count.data(), max_active);
+        int4_grouped_moe_combine(
+            q, pair_out.data(), idx.data(), weight.data(), first_expert,
+            local_experts, seq, kTopK, kHidden, grouped_out.data());
+    };
+
+    baseline();
+    grouped();
+    q.wait();
+    std::vector<bf16> baseline_h(baseline_out.count()), grouped_h(grouped_out.count());
+    baseline_out.download(baseline_h.data(), baseline_h.size());
+    grouped_out.download(grouped_h.data(), grouped_h.size());
+    ErrorStats error = compare(baseline_h, grouped_h);
+
+    for (int i = 0; i < 2; ++i) baseline();
+    for (int i = 0; i < 2; ++i) grouped();
+    q.wait();
+    double baseline_ms = elapsed_ms(q, iterations, baseline);
+    double grouped_ms = elapsed_ms(q, iterations, grouped);
+    auto grouped_routes = [&] {
+        int4_grouped_moe_build_routes(
+            q, idx.data(), first_expert, local_experts, pairs,
+            offsets.data(), tokens.data(), active_experts.data(), active_count.data());
+    };
+    auto grouped_gateup = [&] {
+        matmul_int4_grouped_dpas_gateup_geglu(
+            q, input.data(), kHidden, gate_w.data(), gate_s.data(),
+            offsets.data(), tokens.data(), local_experts, pairs, kTopK,
+            kInter, kGroup, grouped_act.data(), active_experts.data(),
+            active_count.data(), max_active);
+    };
+    auto grouped_down = [&] {
+        matmul_int4_grouped_dpas_down(
+            q, grouped_act.data(), kInter, down_w.data(), down_s.data(),
+            offsets.data(), tokens.data(), local_experts, pairs, kHidden,
+            kGroup, pair_out.data(), active_experts.data(),
+            active_count.data(), max_active);
+    };
+    auto grouped_combine = [&] {
+        int4_grouped_moe_combine(
+            q, pair_out.data(), idx.data(), weight.data(), first_expert,
+            local_experts, seq, kTopK, kHidden, grouped_out.data());
+    };
+    double routes_ms = elapsed_ms(q, iterations, grouped_routes);
+    double gateup_ms = elapsed_ms(q, iterations, grouped_gateup);
+    double down_ms = elapsed_ms(q, iterations, grouped_down);
+    double combine_ms = elapsed_ms(q, iterations, grouped_combine);
+    std::printf("[moe] seq=%d topk=%d H=%d I=%d localE=%d rows=%d | "
+                "baseline %.3f ms | grouped %.3f ms | speedup %.3fx\n",
+                seq, kTopK, kHidden, kInter, local_experts, total_rows,
+                baseline_ms, grouped_ms, baseline_ms / grouped_ms);
+    std::printf("[grouped stages] routes %.3f ms | gateup %.3f ms | "
+                "down %.3f ms | combine %.3f ms\n",
+                routes_ms, gateup_ms, down_ms, combine_ms);
+    std::printf("[correctness] max_abs=%.7g rms=%.7g cosine=%.9f "
+                "bit_mismatch=%zu/%zu\n",
+                error.max_abs, error.rms, error.cosine,
+                error.bit_mismatches, baseline_h.size());
+    if (!std::isfinite(error.cosine) || error.cosine < 0.999)
+        throw std::runtime_error("grouped INT4 DPAS output failed cosine tolerance");
+    return 0;
+}
+
+} // namespace
+
+REGISTER_BENCH("diffusion-int4-grouped-moe",
+    "DiffusionGemma INT4-AWQ per-expert oneDNN vs device-routed grouped DPAS MoE",
+    run)

--- a/src/common/gpu/int4_grouped_moe.hpp
+++ b/src/common/gpu/int4_grouped_moe.hpp
@@ -13,8 +13,37 @@
 // latter is already used by q8_0.hpp and permits direct BF16-bit operands.
 #include "int4.hpp"
 #include "q8_0.hpp" // DPAS builtin declaration / vector operand types.
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
 
 static constexpr int kInt4GroupedDpasBF16 = 0x3000;
+
+// This SPIR-V BF16 operand form is accepted by Xe2/Battlemage.  ACM's IGC
+// requires an int32 A operand for K=16 and rejects the kernel at JIT time, so
+// callers must keep it out of the A770 path.  SYCL reports Intel's GPU
+// architecture version as 20.x for Xe2 and 12.x for ACM.
+inline bool diff_int4_grouped_dpas_device_supported(const sycl::device& device) {
+    const std::string version =
+        device.get_info<sycl::info::device::version>();
+    return std::atoi(version.c_str()) >= 20;
+}
+
+// Limit each DPAS submission to a bounded active-expert slice.  The raw
+// SPV_INTEL subgroup-matrix path has been observed to wedge above roughly
+// 16K work-items, while slicing is effectively free on an in-order queue.
+// DiffusionGemma's 2816-wide down projection launches 2816 work-items per
+// expert, so five experts (14080 work-items) is the largest slice below that
+// threshold. Keep this independently tunable for BMG A/B work; 0 disables
+// slicing.
+inline int diff_int4_grouped_dpas_expert_slice() {
+    static int value = [] {
+        const char* env = std::getenv("DIFF_INT4_GROUPED_DPAS_SLICE");
+        int v = env ? std::atoi(env) : 5;
+        return v < 0 ? 5 : v;
+    }();
+    return value;
+}
 
 // Make a compact expert-major route list entirely on device.  offsets has
 // local_experts+1 entries, and tokens contains the original top-k pair index.
@@ -22,53 +51,71 @@ static constexpr int kInt4GroupedDpasBF16 = 0x3000;
 // activation row.  This deliberately has no host count/download boundary.
 inline void int4_grouped_moe_build_routes(
     sycl::queue& q, const int* expert_idx, int first_expert,
-    int local_experts, int pairs, int32_t* counts, int32_t* offsets,
-    int32_t* cursors, int32_t* tokens)
+    int local_experts, int pairs, int32_t* offsets, int32_t* tokens,
+    int32_t* active_experts, int32_t* active_count)
 {
-    q.memset(counts, 0, (size_t)local_experts * sizeof(int32_t));
+    if (pairs <= 0) {
+        q.memset(offsets, 0, ((size_t)local_experts + 1) * sizeof(int32_t));
+        q.memset(active_count, 0, sizeof(int32_t));
+        return;
+    }
     q.submit([&](sycl::handler& h) {
-        h.parallel_for(sycl::range<1>((size_t)pairs), [=](sycl::id<1> id) {
-            int pair = (int)id[0];
-            int e = expert_idx[pair] - first_expert;
-            if (e < 0 || e >= local_experts) return;
-            sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
-                             sycl::memory_scope::device,
-                             sycl::access::address_space::global_space>
-                count(counts[e]);
-            count.fetch_add(1);
-        });
-    });
-    // E=128, so a serial device prefix is a few dozen instructions and avoids
-    // a host round trip or a general scan temporary.  This is ordered before
-    // the following scatter by the in-order model queue.
-    q.submit([&](sycl::handler& h) {
-        h.single_task([=]() {
-            int32_t running = 0;
-            for (int e = 0; e < local_experts; ++e) {
-                offsets[e] = running;
-                cursors[e] = running;
-                running += counts[e];
+        sycl::local_accessor<int32_t, 1> counts((size_t)local_experts, h);
+        sycl::local_accessor<int32_t, 1> local_offsets((size_t)local_experts + 1, h);
+        h.parallel_for(
+            sycl::nd_range<1>(sycl::range<1>(256), sycl::range<1>(256)),
+            [=](sycl::nd_item<1> it) {
+                int wi = (int)it.get_local_id(0);
+                int nw = (int)it.get_local_range(0);
+                for (int e = wi; e < local_experts; e += nw) counts[e] = 0;
+                it.barrier();
+
+                for (int pair = wi; pair < pairs; pair += nw) {
+                    int e = expert_idx[pair] - first_expert;
+                    if (e < 0 || e >= local_experts) continue;
+                    sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::work_group,
+                                     sycl::access::address_space::local_space>
+                        count(counts[e]);
+                    count.fetch_add(1);
+                }
+                it.barrier();
+
+                if (wi == 0) {
+                    int32_t running = 0;
+                    int32_t active = 0;
+                    for (int e = 0; e < local_experts; ++e) {
+                        int32_t count = counts[e];
+                        local_offsets[e] = running;
+                        counts[e] = running; // reuse as scatter cursors
+                        if (count > 0) active_experts[active++] = e;
+                        running += count;
+                    }
+                    local_offsets[local_experts] = running;
+                    *active_count = active;
+                }
+                it.barrier();
+
+                for (int e = wi; e <= local_experts; e += nw)
+                    offsets[e] = local_offsets[e];
+                for (int pair = wi; pair < pairs; pair += nw) {
+                    int e = expert_idx[pair] - first_expert;
+                    if (e < 0 || e >= local_experts) continue;
+                    sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::work_group,
+                                     sycl::access::address_space::local_space>
+                        cursor(counts[e]);
+                    tokens[cursor.fetch_add(1)] = pair;
+                }
             }
-            offsets[local_experts] = running;
-        });
-    });
-    q.submit([&](sycl::handler& h) {
-        h.parallel_for(sycl::range<1>((size_t)pairs), [=](sycl::id<1> id) {
-            int pair = (int)id[0];
-            int e = expert_idx[pair] - first_expert;
-            if (e < 0 || e >= local_experts) return;
-            sycl::atomic_ref<int32_t, sycl::memory_order::relaxed,
-                             sycl::memory_scope::device,
-                             sycl::access::address_space::global_space>
-                cursor(cursors[e]);
-            tokens[cursor.fetch_add(1)] = pair;
-        });
+        );
     });
 }
 
-// Fused gate/up W4A16 GEMM + DiffusionGemma's GeGLU.  One 16-wide subgroup
-// handles one local expert and 16 intermediate channels, looping over its
-// compacted pair list in eight-row DPAS tiles.  `gate_w` points at raw packed
+// Fused gate/up W4A16 GEMM + DiffusionGemma's GeGLU.  One 64-lane work-group
+// handles one active local expert and 64 intermediate channels (four
+// 16-wide DPAS subgroups), looping over its compacted pair list in eight-row
+// tiles. `gate_w` points at raw packed
 // [2*inter, hidden/2] rows and `gate_s` points at [hidden/group, 2*inter].
 inline void matmul_int4_grouped_dpas_gateup_geglu(
     sycl::queue& q,
@@ -76,21 +123,28 @@ inline void matmul_int4_grouped_dpas_gateup_geglu(
     const uint8_t* const* gate_w, const bf16* const* gate_s,
     const int32_t* expert_offsets, const int32_t* expert_tokens,
     int local_experts, int pairs, int top_k, int inter, int group_size,
-    bf16* intermediate)
+    bf16* intermediate, const int32_t* active_experts,
+    const int32_t* active_count, int max_active)
 {
-    if (hidden % 16 || inter % 16 || hidden % group_size || group_size != 32)
-        throw std::runtime_error("grouped INT4 DPAS requires H/I % 16 and AWQ group_size=32");
-    if (pairs <= 0) return;
+    if (hidden % 16 || inter % 64 || hidden % group_size || group_size != 32)
+        throw std::runtime_error("grouped INT4 DPAS requires H % 16, I % 64 and AWQ group_size=32");
+    if (pairs <= 0 || max_active <= 0) return;
     constexpr float SQRT_2_OVER_PI = 0.7978845608028654f;
     constexpr float COEF = 0.044715f;
-    q.submit([&](sycl::handler& h) {
-        h.parallel_for(
-            sycl::nd_range<2>(sycl::range<2>((size_t)local_experts, (size_t)inter),
-                              sycl::range<2>(1, 16)),
+    int slice = diff_int4_grouped_dpas_expert_slice();
+    int estep = slice > 0 ? slice : max_active;
+    for (int a0 = 0; a0 < max_active; a0 += estep) {
+        int ec = std::min(estep, max_active - a0);
+        q.submit([&](sycl::handler& h) {
+          h.parallel_for(
+            sycl::nd_range<2>(sycl::range<2>((size_t)ec, (size_t)inter),
+                              sycl::range<2>(1, 64)),
             [=](sycl::nd_item<2> it) [[sycl::reqd_sub_group_size(16)]] {
-                int e = (int)it.get_group(0);
-                int lane = (int)it.get_local_id(1);
-                int n = (int)it.get_group(1) * 16 + lane;
+                int a = a0 + (int)it.get_group(0);
+                if (a >= *active_count) return;
+                int e = active_experts[a];
+                int lane = (int)it.get_local_id(1) & 15;
+                int n = (int)it.get_global_id(1);
                 int t0 = expert_offsets[e];
                 int t1 = expert_offsets[e + 1];
                 if (t0 >= t1) return;
@@ -101,17 +155,25 @@ inline void matmul_int4_grouped_dpas_gateup_geglu(
                 const int out_features = 2 * inter;
 
                 for (int m0 = t0; m0 < t1; m0 += 8) {
+                    int pair[8], token[8];
+                    for (int m = 0; m < 8; ++m) {
+                        int pos = m0 + m < t1 ? m0 + m : t1 - 1;
+                        pair[m] = expert_tokens[pos];
+                        token[m] = pair[m] / top_k;
+                    }
                     diff_dpas_v8f cg = {0,0,0,0,0,0,0,0};
                     diff_dpas_v8f cu = {0,0,0,0,0,0,0,0};
                     for (int k0 = 0; k0 < hidden; k0 += 16) {
                         int kg = k0 / group_size;
                         float sg = bf16_to_float(s[(size_t)kg * out_features + n]);
                         float su = bf16_to_float(s[(size_t)kg * out_features + inter + n]);
-                        const uint8_t* wg = w + (size_t)n * packed_k + k0 / 2;
-                        const uint8_t* wu = w + (size_t)(inter + n) * packed_k + k0 / 2;
+                        uint64_t gate_word, up_word;
+                        std::memcpy(&gate_word, w + (size_t)n * packed_k + k0 / 2, 8);
+                        std::memcpy(&up_word, w + (size_t)(inter + n) * packed_k + k0 / 2, 8);
                         diff_dpas_v8i bg, bu;
                         for (int j = 0; j < 8; ++j) {
-                            uint8_t gbyte = wg[j], ubyte = wu[j];
+                            uint8_t gbyte = (uint8_t)(gate_word >> (8 * j));
+                            uint8_t ubyte = (uint8_t)(up_word >> (8 * j));
                             int g0 = (int)(gbyte & 0x0f); if (g0 >= 8) g0 -= 16;
                             int g1 = (int)(gbyte >> 4);   if (g1 >= 8) g1 -= 16;
                             int u0 = (int)(ubyte & 0x0f); if (u0 >= 8) u0 -= 16;
@@ -125,26 +187,26 @@ inline void matmul_int4_grouped_dpas_gateup_geglu(
                         }
                         diff_dpas_v8s av;
                         int kk = k0 + lane;
-                        for (int m = 0; m < 8; ++m) {
-                            int pos = m0 + m < t1 ? m0 + m : t1 - 1;
-                            int pair = expert_tokens[pos];
-                            av[m] = (short)input[(size_t)(pair / top_k) * hidden + kk];
-                        }
+                        for (int m = 0; m < 8; ++m)
+                            av[m] = (short)input[(size_t)token[m] * hidden + kk];
                         cg = __spirv_SubgroupMatrixMultiplyAccumulateINTEL(
                             16, av, bg, cg, kInt4GroupedDpasBF16);
                         cu = __spirv_SubgroupMatrixMultiplyAccumulateINTEL(
                             16, av, bu, cu, kInt4GroupedDpasBF16);
                     }
                     for (int m = 0; m < 8 && m0 + m < t1; ++m) {
-                        int pair = expert_tokens[m0 + m];
-                        float g = cg[m], u = cu[m];
+                        // Match the original oneDNN GEMM -> BF16 buffer ->
+                        // GeGLU boundary before fusing the epilogue.
+                        float g = bf16_to_float(float_to_bf16(cg[m]));
+                        float u = bf16_to_float(float_to_bf16(cu[m]));
                         float inner = SQRT_2_OVER_PI * (g + COEF * g * g * g);
-                        intermediate[(size_t)pair * inter + n] = float_to_bf16(
+                        intermediate[(size_t)pair[m] * inter + n] = float_to_bf16(
                             0.5f * g * (1.0f + sycl::tanh(inner)) * u);
                     }
                 }
             });
-    });
+        });
+    }
 }
 
 // Grouped W4A16 down projection.  Input/output rows use the original pair
@@ -156,19 +218,26 @@ inline void matmul_int4_grouped_dpas_down(
     const uint8_t* const* down_w, const bf16* const* down_s,
     const int32_t* expert_offsets, const int32_t* expert_tokens,
     int local_experts, int pairs, int hidden, int group_size,
-    bf16* output)
+    bf16* output, const int32_t* active_experts,
+    const int32_t* active_count, int max_active)
 {
-    if (hidden % 16 || inter % 16 || inter % group_size || group_size != 32)
-        throw std::runtime_error("grouped INT4 DPAS requires H/I % 16 and AWQ group_size=32");
-    if (pairs <= 0) return;
-    q.submit([&](sycl::handler& h) {
-        h.parallel_for(
-            sycl::nd_range<2>(sycl::range<2>((size_t)local_experts, (size_t)hidden),
-                              sycl::range<2>(1, 16)),
+    if (hidden % 64 || inter % 16 || inter % group_size || group_size != 32)
+        throw std::runtime_error("grouped INT4 DPAS requires H % 64, I % 16 and AWQ group_size=32");
+    if (pairs <= 0 || max_active <= 0) return;
+    int slice = diff_int4_grouped_dpas_expert_slice();
+    int estep = slice > 0 ? slice : max_active;
+    for (int a0 = 0; a0 < max_active; a0 += estep) {
+        int ec = std::min(estep, max_active - a0);
+        q.submit([&](sycl::handler& h) {
+          h.parallel_for(
+            sycl::nd_range<2>(sycl::range<2>((size_t)ec, (size_t)hidden),
+                              sycl::range<2>(1, 64)),
             [=](sycl::nd_item<2> it) [[sycl::reqd_sub_group_size(16)]] {
-                int e = (int)it.get_group(0);
-                int lane = (int)it.get_local_id(1);
-                int n = (int)it.get_group(1) * 16 + lane;
+                int a = a0 + (int)it.get_group(0);
+                if (a >= *active_count) return;
+                int e = active_experts[a];
+                int lane = (int)it.get_local_id(1) & 15;
+                int n = (int)it.get_global_id(1);
                 int t0 = expert_offsets[e];
                 int t1 = expert_offsets[e + 1];
                 if (t0 >= t1) return;
@@ -177,14 +246,20 @@ inline void matmul_int4_grouped_dpas_down(
                 const bf16* s = down_s[e];
                 const int packed_k = inter / 2;
                 for (int m0 = t0; m0 < t1; m0 += 8) {
+                    int pair[8];
+                    for (int m = 0; m < 8; ++m) {
+                        int pos = m0 + m < t1 ? m0 + m : t1 - 1;
+                        pair[m] = expert_tokens[pos];
+                    }
                     diff_dpas_v8f c = {0,0,0,0,0,0,0,0};
                     for (int k0 = 0; k0 < inter; k0 += 16) {
                         int kg = k0 / group_size;
                         float scale = bf16_to_float(s[(size_t)kg * hidden + n]);
-                        const uint8_t* wr = w + (size_t)n * packed_k + k0 / 2;
+                        uint64_t weight_word;
+                        std::memcpy(&weight_word, w + (size_t)n * packed_k + k0 / 2, 8);
                         diff_dpas_v8i bv;
                         for (int j = 0; j < 8; ++j) {
-                            uint8_t byte = wr[j];
+                            uint8_t byte = (uint8_t)(weight_word >> (8 * j));
                             int v0 = (int)(byte & 0x0f); if (v0 >= 8) v0 -= 16;
                             int v1 = (int)(byte >> 4);   if (v1 >= 8) v1 -= 16;
                             uint16_t b0 = float_to_bf16((float)v0 * scale);
@@ -193,19 +268,42 @@ inline void matmul_int4_grouped_dpas_down(
                         }
                         diff_dpas_v8s av;
                         int kk = k0 + lane;
-                        for (int m = 0; m < 8; ++m) {
-                            int pos = m0 + m < t1 ? m0 + m : t1 - 1;
-                            int pair = expert_tokens[pos];
-                            av[m] = (short)intermediate[(size_t)pair * inter + kk];
-                        }
+                        for (int m = 0; m < 8; ++m)
+                            av[m] = (short)intermediate[(size_t)pair[m] * inter + kk];
                         c = __spirv_SubgroupMatrixMultiplyAccumulateINTEL(
                             16, av, bv, c, kInt4GroupedDpasBF16);
                     }
-                    for (int m = 0; m < 8 && m0 + m < t1; ++m) {
-                        int pair = expert_tokens[m0 + m];
-                        output[(size_t)pair * hidden + n] = float_to_bf16(c[m]);
-                    }
+                    for (int m = 0; m < 8 && m0 + m < t1; ++m)
+                        output[(size_t)pair[m] * hidden + n] = float_to_bf16(c[m]);
                 }
             });
+        });
+    }
+}
+
+// Combine one expert shard's pair-indexed output. Routing weights remain here
+// (after the down projection), preserving DiffusionGemma's original rounding
+// and weighting order. Pairs routed to another shard are skipped.
+inline void int4_grouped_moe_combine(
+    sycl::queue& q, const bf16* pair_out,
+    const int* expert_idx, const float* pair_weight,
+    int first_expert, int local_experts,
+    int seq, int top_k, int hidden, bf16* out)
+{
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::range<2>((size_t)seq, (size_t)hidden),
+                       [=](sycl::id<2> id) {
+            int token = (int)id[0];
+            int dim = (int)id[1];
+            float acc = 0.0f;
+            for (int k = 0; k < top_k; ++k) {
+                int pair = token * top_k + k;
+                int e = expert_idx[pair] - first_expert;
+                if (e >= 0 && e < local_experts)
+                    acc += pair_weight[pair] *
+                           bf16_to_float(pair_out[(size_t)pair * hidden + dim]);
+            }
+            out[(size_t)token * hidden + dim] = float_to_bf16(acc);
+        });
     });
 }

--- a/src/common/gpu/placement.cpp
+++ b/src/common/gpu/placement.cpp
@@ -151,6 +151,50 @@ int resolve_diffusion_split_layer(const DiffConfig& cfg, const DiffPlacementOpti
     return split_layer;
 }
 
+std::vector<int> parse_expert_ranges(const std::string& csv) {
+    std::vector<int> counts;
+    size_t pos = 0;
+    while (pos <= csv.size()) {
+        size_t comma = csv.find(',', pos);
+        std::string tok = csv.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
+        if (tok.empty())
+            throw std::runtime_error("--experts ranges: expected comma-separated counts, got '" + csv + "'");
+        int n;
+        try {
+            n = std::stoi(tok);
+        } catch (...) {
+            throw std::runtime_error("--experts ranges: invalid count '" + tok + "'");
+        }
+        if (n < 0)
+            throw std::runtime_error("--experts ranges: counts must be non-negative, got '" + tok + "'");
+        counts.push_back(n);
+        if (comma == std::string::npos) break;
+        pos = comma + 1;
+    }
+    return counts;
+}
+
+std::vector<std::pair<int, int>> expert_shard_bounds(int E, int G, const std::vector<int>& counts) {
+    std::vector<std::pair<int, int>> bounds(G);
+    if (counts.empty()) {
+        for (int g = 0; g < G; ++g)
+            bounds[g] = {g * E / G, (g + 1) * E / G};
+        return bounds;
+    }
+    if ((int)counts.size() != G)
+        throw std::runtime_error("--experts ranges: got " + std::to_string(counts.size()) +
+                                 " counts but " + std::to_string(G) + " GPU engine(s) are available");
+    int first = 0;
+    for (int g = 0; g < G; ++g) {
+        bounds[g] = {first, first + counts[g]};
+        first += counts[g];
+    }
+    if (first != E)
+        throw std::runtime_error("--experts ranges: counts sum to " + std::to_string(first) +
+                                 " but the model has " + std::to_string(E) + " experts");
+    return bounds;
+}
+
 void print_diffusion_placement(const DiffConfig& cfg, int split_layer, const DiffPlacementOptions& placement) {
     int G = GpuEngine::count();
     int L = cfg.text.num_hidden_layers;
@@ -167,11 +211,9 @@ void print_diffusion_placement(const DiffConfig& cfg, int split_layer, const Dif
 
     size_t expert_layer = expert_bytes_per_layer(cfg.text, cfg.is_nvfp4_quantized());
     if (expert_mode == DiffExpertPlacementMode::Shard) {
-        for (int g = 0; g < G; ++g) {
-            int first = g * E / G;
-            int last = (g + 1) * E / G;
-            expert_bytes[g] = expert_layer * (size_t)(last - first) / (size_t)E * (size_t)L;
-        }
+        auto bounds = expert_shard_bounds(E, G, placement.expert_counts);
+        for (int g = 0; g < G; ++g)
+            expert_bytes[g] = expert_layer * (size_t)(bounds[g].second - bounds[g].first) / (size_t)E * (size_t)L;
     } else {
         for (int l = 0; l < L; ++l) {
             int owner = (l < split_layer) ? 0 : 1;
@@ -206,11 +248,9 @@ void print_diffusion_placement(const DiffConfig& cfg, int split_layer, const Dif
 
     std::printf("[placement] experts:\n");
     if (expert_mode == DiffExpertPlacementMode::Shard) {
-        for (int g = 0; g < G; ++g) {
-            int first = g * E / G;
-            int last = (g + 1) * E / G;
-            std::printf("[placement]   GPU%d: experts [%d, %d) for each MoE layer\n", g, first, last);
-        }
+        auto bounds = expert_shard_bounds(E, G, placement.expert_counts);
+        for (int g = 0; g < G; ++g)
+            std::printf("[placement]   GPU%d: experts [%d, %d) for each MoE layer\n", g, bounds[g].first, bounds[g].second);
     } else {
         for (int l = 0; l < L; ++l) {
             int owner = (l < split_layer) ? 0 : 1;

--- a/src/common/gpu/placement.hpp
+++ b/src/common/gpu/placement.hpp
@@ -2,6 +2,8 @@
 #include "../../modeling/diffusion_gemma/config.hpp"
 
 #include <string>
+#include <utility>
+#include <vector>
 
 // User-facing placement knobs.  Auto preserves the current default behavior.
 enum class DiffLayerPlacementMode { Auto, Single, Split };
@@ -11,6 +13,9 @@ struct DiffPlacementOptions {
     DiffLayerPlacementMode layer_mode = DiffLayerPlacementMode::Auto;
     DiffExpertPlacementMode expert_mode = DiffExpertPlacementMode::Auto;
     int layer_split = -1;  // only used by LayerPlacementMode::Split
+    // Per-GPU expert counts for Shard mode (--experts ranges:N,N,...).
+    // Empty means an even split across all GPU engines.
+    std::vector<int> expert_counts;
 };
 
 const char* layer_placement_name(DiffLayerPlacementMode mode);
@@ -20,3 +25,9 @@ DiffExpertPlacementMode resolve_expert_placement(DiffExpertPlacementMode mode);
 
 int resolve_diffusion_split_layer(const DiffConfig& cfg, const DiffPlacementOptions& placement);
 void print_diffusion_placement(const DiffConfig& cfg, int split_layer, const DiffPlacementOptions& placement);
+
+// Parses "48,80" into per-GPU expert counts {48, 80}.
+std::vector<int> parse_expert_ranges(const std::string& csv);
+// Resolves [first, last) expert bounds per GPU. With empty counts this is the
+// even split; otherwise counts must have exactly G entries summing to E.
+std::vector<std::pair<int, int>> expert_shard_bounds(int E, int G, const std::vector<int>& counts);

--- a/src/diffusion_bench.cpp
+++ b/src/diffusion_bench.cpp
@@ -90,7 +90,10 @@ void apply_experts_spec(const std::string& value, DiffPlacementOptions& placemen
         placement.expert_mode = DiffExpertPlacementMode::Shard;
     } else if (value == "local") {
         throw std::runtime_error("--experts local was renamed; use --experts layer-owner");
-    } else if (value == "replicate" || value.rfind("ranges:", 0) == 0 || value.rfind("gpus:", 0) == 0) {
+    } else if (value.rfind("ranges:", 0) == 0) {
+        placement.expert_mode = DiffExpertPlacementMode::Shard;
+        placement.expert_counts = parse_expert_ranges(value.substr(7));
+    } else if (value == "replicate" || value.rfind("gpus:", 0) == 0) {
         unsupported_placement_value("--experts", value);
     } else {
         throw std::runtime_error("--experts must be one of: auto, layer-owner, replicate, shard, ranges:N,N,..., gpus:N");

--- a/src/diffusion_main.cpp
+++ b/src/diffusion_main.cpp
@@ -104,7 +104,10 @@ static void apply_experts_spec(const std::string& value, DiffPlacementOptions& p
         placement.expert_mode = DiffExpertPlacementMode::Shard;
     } else if (value == "local") {
         throw std::runtime_error("--experts local was renamed; use --experts layer-owner");
-    } else if (value == "replicate" || value.rfind("ranges:", 0) == 0 || value.rfind("gpus:", 0) == 0) {
+    } else if (value.rfind("ranges:", 0) == 0) {
+        placement.expert_mode = DiffExpertPlacementMode::Shard;
+        placement.expert_counts = parse_expert_ranges(value.substr(7));
+    } else if (value == "replicate" || value.rfind("gpus:", 0) == 0) {
         unsupported_placement_value("--experts", value);
     } else {
         throw std::runtime_error("--experts must be one of: auto, layer-owner, replicate, shard, ranges:N,N,..., gpus:N");

--- a/src/modeling/diffusion_gemma/loader.cpp
+++ b/src/modeling/diffusion_gemma/loader.cpp
@@ -616,7 +616,8 @@ static std::vector<float> host_floats(const TensorView& tv) {
 DiffWeights load_diffusion_weights(const std::string& model_dir,
                                    const DiffConfig& cfg,
                                    int split_layer,
-                                   DiffExpertPlacementMode expert_mode) {
+                                   DiffExpertPlacementMode expert_mode,
+                                   const std::vector<int>& expert_counts) {
     std::unique_ptr<TensorSource> source;
     const char* gguf_path = std::getenv("DIFF_GGUF_Q8_WEIGHTS");
     if (gguf_path && gguf_path[0]) {
@@ -715,6 +716,10 @@ DiffWeights load_diffusion_weights(const std::string& model_dir,
             int E = cfg.text.num_experts;
             DiffExpertPlacementMode resolved_experts = resolve_expert_placement(expert_mode);
             int G = (resolved_experts == DiffExpertPlacementMode::Shard) ? GpuEngine::count() : 1;
+            std::vector<std::pair<int, int>> bounds =
+                (resolved_experts == DiffExpertPlacementMode::Shard)
+                    ? expert_shard_bounds(E, G, expert_counts)
+                    : std::vector<std::pair<int, int>>{{0, E}};
             bool experts_q8     = sf.has(p + "experts.gate_up_proj") &&
                 sf.get(p + "experts.gate_up_proj").dtype == "Q8_0";
             bool experts_packed = sf.has(p + "experts.0.gate_proj.weight_packed");
@@ -723,8 +728,8 @@ DiffWeights load_diffusion_weights(const std::string& model_dir,
             bool experts_nvfp4  = experts_packed && !experts_int4;
             lw.moe.expert_shards.reserve(G);
             for (int eg = 0; eg < G; ++eg) {
-                int first = (resolved_experts == DiffExpertPlacementMode::Shard) ? eg * E / G : 0;
-                int last  = (resolved_experts == DiffExpertPlacementMode::Shard) ? (eg + 1) * E / G : E;
+                int first = bounds[eg].first;
+                int last  = bounds[eg].second;
                 if (first == last) continue;
                 int shard_gpu = (resolved_experts == DiffExpertPlacementMode::Shard) ? eg : gpu;
                 auto& eq = GpuEngine::get(shard_gpu).queue;

--- a/src/modeling/diffusion_gemma/loader.hpp
+++ b/src/modeling/diffusion_gemma/loader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include "config.hpp"
 #include "weights.hpp"
 #include "../../common/gpu/placement.hpp"
@@ -8,4 +9,5 @@
 DiffWeights load_diffusion_weights(const std::string& model_dir,
                                    const DiffConfig& cfg,
                                    int split_layer,
-                                   DiffExpertPlacementMode expert_mode);
+                                   DiffExpertPlacementMode expert_mode,
+                                   const std::vector<int>& expert_counts = {});

--- a/src/modeling/diffusion_gemma/model.cpp
+++ b/src/modeling/diffusion_gemma/model.cpp
@@ -120,7 +120,8 @@ DiffusionGemmaModel::DiffusionGemmaModel(const std::string& model_dir, int max_s
 
     embed_scale_ = bf16_to_float(float_to_bf16(std::sqrt((float)cfg_.text.hidden_size)));
 
-    w_      = load_diffusion_weights(model_dir, cfg_, split_layer_, resolved_placement.expert_mode);
+    w_      = load_diffusion_weights(model_dir, cfg_, split_layer_, resolved_placement.expert_mode,
+                                     resolved_placement.expert_counts);
     enc_kv_ = DiffKvCache(cfg_, max_seq_len, split_layer_);
     reserve_activation_arenas(cfg_, max_seq_len);
 }


### PR DESCRIPTION
## Summary

Shard mode previously split experts evenly across GPUs (`g*E/G`). On heterogeneous multi-GPU setups (e.g. B580 12 GB + A770 16 GB) an even expert split wastes the larger card's headroom and forces a worse layer split. This implements the previously-stubbed `--experts ranges:N,N,...` CLI value so expert shards can be sized per GPU.

Example: `--layers split:10 --experts ranges:44,84` puts 44 experts on a B580 and 84 on an A770 (previously rejected as "not implemented").

## Changes

- **placement**: `parse_expert_ranges()` + `expert_shard_bounds()`; empty counts preserve the existing even-split behavior. Validates that counts match GPU count and sum to E.
- **cli**: wire `ranges:` into `diffusion_main`, `diffusion_bench`, `arcaine_server`
- **loader**: thread per-GPU expert counts through `load_diffusion_weights` and load per shard bounds
- **int4_grouped_moe**: rework grouped MoE kernel to handle uneven shards
- **bench**: new `diffusion_int4_grouped_moe_bench` kernel bench + run script
- **cmake**: pass `spir64_gen` triple to `-Xspirv-translator` when explicit `ARCAINE_SYCL_TARGETS` AOT targets are set (icpx cannot deduce the triple in that configuration)
- **docker**: bump `ONEDNN_VERSION` to `main`

## Testing

- Built and ran on B580 + A770 with `--layers split:10 --experts ranges:44,84`; placement log shows per-GPU expert ranges and memory (GPU0 6.24 GB / GPU1 9.07 GB)
- Served 26B-A4B AWQ INT4 model at `--max-seq 32768`; verified with 30k-token prompt round-trips
- Error paths: mismatched count vs GPU engines and counts not summing to E both throw at startup