### PR TITLE
qwen3_5: unify the DeltaNet conv-state layout; stop batch size selecting a kernel

### DIFF
--- a/src/modeling/qwen3_5/kernels.hpp
+++ b/src/modeling/qwen3_5/kernels.hpp
@@ -138,8 +138,12 @@ inline void qwen35_conv_causal(sycl::queue& queue, const bf16* input,
                 if (source_token >= 0) {
                     sample = bf16_to_float(input[(size_t)source_token * input_stride + channel]);
                 } else if (has_state) {
+                    // Time-major [history, channel]. The conv state is shared
+                    // with the fused decode path, which indexes it this way
+                    // (see qwen35_update_conv_state_time_major), so both
+                    // readers must agree on one layout.
                     int state_index = history + source_token;
-                    sample = bf16_to_float(old_state[(size_t)channel * history + state_index]);
+                    sample = bf16_to_float(old_state[(size_t)state_index * channels + channel]);
                 }
                 sum += bf16_to_float(weight[(size_t)channel * kernel + tap]) * sample;
             }
@@ -163,13 +167,15 @@ inline void qwen35_update_conv_state(sycl::queue& queue, const bf16* input,
                 if (source_token >= 0) {
                     next[slot] = input[(size_t)source_token * input_stride + channel];
                 } else if (had_state) {
-                    next[slot] = state[(size_t)channel * history + history + source_token];
+                    next[slot] = state[(size_t)(history + source_token) * channels + channel];
                 } else {
                     next[slot] = bf16{0};
                 }
             }
+            // Time-major [history, channel], matching qwen35_conv_causal and
+            // qwen35_update_conv_state_time_major.
             for (int slot = 0; slot < history; ++slot)
-                state[(size_t)channel * history + slot] = next[slot];
+                state[(size_t)slot * channels + channel] = next[slot];
         });
     });
 }

--- a/src/modeling/qwen3_5/operators.hpp
+++ b/src/modeling/qwen3_5/operators.hpp
@@ -78,6 +78,19 @@ inline bool qwen35_fused_esimd_delta_decode_enabled() {
     return enabled;
 }
 
+// Largest batch the per-token fused decode core is used for. Above this the
+// chunked path wins, and prefill is far above it. Speculative verify windows
+// are a handful of tokens, so the default covers them.
+inline int qwen35_fused_decode_max_seq() {
+    static int limit = [] {
+        const char* value = std::getenv("ARCAINE_QWEN35_FUSED_DECODE_MAX_SEQ");
+        if (!value) return 8;
+        int parsed = std::atoi(value);
+        return parsed > 0 ? parsed : 8;
+    }();
+    return limit;
+}
+
 inline void matmul_proj(const bf16* A, int M, int K, const Qwen35Proj& W,
                         bf16* C, GpuEngine& context) {
     if (const auto* w = std::get_if<Fp8Linear>(&W))
@@ -198,34 +211,58 @@ inline void qwen35_linear_attention_forward(
         matmul_proj(hidden, seq, c.hidden_size, weights.in_proj_qkv,
                     workspace.tmp0.data(), context);
     }
-    if (seq == 1 && weights.fused_projections &&
-        qwen35_fused_esimd_delta_decode_enabled()) {
-        if (qwen35_fused_ba_projection_enabled())
-            matmul_bf16(hidden, 1, c.hidden_size, weights.in_proj_ba.data(),
-                        2 * heads, workspace.tmp1.data(), context);
-        else {
-            matmul_bf16(hidden, 1, c.hidden_size, weights.in_proj_b.data(), heads,
-                        workspace.tmp1.data(), context);
-            matmul_bf16(hidden, 1, c.hidden_size, weights.in_proj_a.data(), heads,
-                        workspace.tmp1.data() + heads, context);
+    // The fused decode core handles one token, so a short batch runs it once
+    // per token rather than falling through to the chunked path below. Batch
+    // size then stops selecting between two implementations that do not agree
+    // numerically: before this, a two-token forward and two one-token forwards
+    // over the same tokens produced different logits, which is visible as soon
+    // as anything verifies a batch against sequential decoding.
+    //
+    // Only the recurrent core loops. The projection above is already batched
+    // over the whole window, so this re-reads the recurrent state and the small
+    // conv/gate tensors, not the weights.
+    if (seq >= 1 && seq <= qwen35_fused_decode_max_seq() &&
+        weights.fused_projections && qwen35_fused_esimd_delta_decode_enabled()) {
+        for (int token = 0; token < seq; ++token) {
+            const bf16* token_hidden = hidden + (size_t)token * c.hidden_size;
+            const bf16* projected =
+                workspace.tmp0.data() + (size_t)token * projected_stride;
+            bf16* ba = workspace.tmp1.data() + (size_t)token * 2 * heads;
+            bf16* core = workspace.tmp4.data() + (size_t)token * value_dim;
+            bf16* gate = workspace.tmp2.data() + (size_t)token * value_dim;
+
+            // Kept at M=1 so a token sees the same projection arithmetic it
+            // would have seen decoding alone. These weights are a few hundred
+            // KB against the tens of GB a decode step already moves.
+            if (qwen35_fused_ba_projection_enabled())
+                matmul_bf16(token_hidden, 1, c.hidden_size,
+                            weights.in_proj_ba.data(), 2 * heads, ba, context);
+            else {
+                matmul_bf16(token_hidden, 1, c.hidden_size,
+                            weights.in_proj_b.data(), heads, ba, context);
+                matmul_bf16(token_hidden, 1, c.hidden_size,
+                            weights.in_proj_a.data(), heads, ba + heads, context);
+            }
+            qwen35_delta_decode_fused_esimd(
+                queue, projected, projected_stride,
+                weights.conv1d_time_major.data(), cache.conv_state.data(),
+                weights.A_log.data(), weights.dt_bias.data(), ba,
+                cache.recurrent_state.data(), core, gate,
+                c.linear_num_key_heads, heads, c.linear_key_head_dim,
+                c.linear_value_head_dim, conv_dim, c.linear_conv_kernel_dim,
+                c.rms_norm_eps);
+            // Shifts this token into the history before the next reads it. The
+            // in-order queue keeps the core and the update interleaved.
+            qwen35_update_conv_state_time_major(queue, projected,
+                                                projected_stride,
+                                                cache.conv_state.data(), conv_dim);
         }
-        qwen35_delta_decode_fused_esimd(
-            queue, workspace.tmp0.data(), projected_stride,
-            weights.conv1d_time_major.data(), cache.conv_state.data(),
-            weights.A_log.data(), weights.dt_bias.data(), workspace.tmp1.data(),
-            cache.recurrent_state.data(), workspace.tmp4.data(),
-            workspace.tmp2.data(), c.linear_num_key_heads, heads,
-            c.linear_key_head_dim, c.linear_value_head_dim, conv_dim,
-            c.linear_conv_kernel_dim, c.rms_norm_eps);
-        qwen35_update_conv_state_time_major(
-            queue, workspace.tmp0.data(), projected_stride,
-            cache.conv_state.data(), conv_dim);
         cache.has_state = true;
         gated_rmsnorm(
             queue, workspace.tmp4.data(), workspace.tmp2.data(),
-            weights.norm.data(), workspace.tmp4.data(), heads,
+            weights.norm.data(), workspace.tmp4.data(), seq * heads,
             c.linear_value_head_dim, c.rms_norm_eps);
-        matmul_proj(workspace.tmp4.data(), 1, value_dim, weights.out_proj,
+        matmul_proj(workspace.tmp4.data(), seq, value_dim, weights.out_proj,
                     output, context);
         return;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,20 @@ if(TARGET arcaine_model_qwen3_5)
     add_test(NAME modeling/qwen3_5/output_parser
              COMMAND arcaine_test_qwen3_5_output_parser)
 
+    # Conv-state layout contract between the chunked and fused decode paths.
+    # Needs a GPU but no model dir, so it runs under ctest.
+    add_executable(arcaine_test_qwen3_5_conv_state_layout
+        ${CMAKE_CURRENT_SOURCE_DIR}/modeling/qwen3_5/test_conv_state_layout.cpp)
+    target_link_libraries(arcaine_test_qwen3_5_conv_state_layout PRIVATE
+        arcaine_model_qwen3_5 DNNL::dnnl)
+    target_compile_options(arcaine_test_qwen3_5_conv_state_layout PRIVATE
+        -fsycl -fno-sycl-id-queries-fit-in-int -O2 ${ARCAINE_SYCL_TARGET_FLAG})
+    target_link_options(arcaine_test_qwen3_5_conv_state_layout PRIVATE
+        -fsycl ${ARCAINE_SYCL_TARGET_FLAG}
+        -Xspirv-translator -spirv-ext=+SPV_INTEL_subgroup_matrix_multiply_accumulate)
+    add_test(NAME modeling/qwen3_5/conv_state_layout
+             COMMAND arcaine_test_qwen3_5_conv_state_layout)
+
     add_executable(arcaine_smoke_qwen35
         ${CMAKE_CURRENT_SOURCE_DIR}/modeling/qwen3_5/smoke_service.cpp)
     target_link_libraries(arcaine_smoke_qwen35 PRIVATE arcaine_model_qwen3_5 DNNL::dnnl)

--- a/tests/modeling/qwen3_5/test_conv_state_layout.cpp
+++ b/tests/modeling/qwen3_5/test_conv_state_layout.cpp
@@ -1,0 +1,187 @@
+// Qwen3.5 DeltaNet conv-state layout contract.
+//
+// One conv-state buffer is written and read by two paths. The chunked path
+// (qwen35_conv_causal + qwen35_update_conv_state) serves prefill and any batch
+// wider than the fused decode window; the fused ESIMD decode path
+// (qwen35_delta_decode_fused_esimd + qwen35_update_conv_state_time_major)
+// serves single tokens. Prefill therefore always hands its state to the other
+// path, and nothing converts between them, so they have to index it the same
+// way.
+//
+// They did not. The chunked path used channel-major, state[channel*history +
+// slot]; the fused path uses time-major, state[slot*channels + channel]. With
+// conv_dim 10240 against history 3 those are unrelated addresses, so the first
+// decode tokens after every prompt convolved over the wrong history and only
+// recovered once `history` real tokens had shifted through. The failure is
+// silent: text stays fluent, and the existing decode-fusion benchmark misses it
+// because it gives each path its own state buffer and so never crosses the
+// boundary.
+//
+// Needs a GPU; needs no model.
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include "check.hpp"
+#include "runtime/gpu/buffer.hpp"
+#include "runtime/gpu/engine.hpp"
+#include "modeling/qwen3_5/kernels.hpp"
+
+using namespace qwen35_kernels;
+
+namespace {
+
+constexpr int kChannels = 64;
+constexpr int kKernel = 4;
+constexpr int kHistory = kKernel - 1;
+
+std::vector<bf16> sample_vector(size_t n, uint32_t seed) {
+    std::vector<bf16> out(n);
+    uint32_t state = seed;
+    for (size_t i = 0; i < n; ++i) {
+        state = state * 1664525u + 1013904223u;
+        out[i] = float_to_bf16((static_cast<int>((state >> 16) & 2047u) - 1024) /
+                               1024.0f);
+    }
+    return out;
+}
+
+std::vector<bf16> download(const GpuBuffer<bf16>& buffer) {
+    std::vector<bf16> host(buffer.count());
+    buffer.download(host.data(), host.size());
+    return host;
+}
+
+// Reports one line per check rather than one per element: a layout mismatch
+// differs in most of a 64-channel buffer, and thousands of identical failures
+// bury the result.
+struct Mismatch {
+    int count = 0;
+    size_t first = 0;
+    float got = 0.0f, want = 0.0f;
+
+    void observe(size_t index, bf16 a, bf16 b) {
+        if (a == b) return;
+        if (count == 0) {
+            first = index;
+            got = bf16_to_float(a);
+            want = bf16_to_float(b);
+        }
+        ++count;
+    }
+    void report(const char* label, size_t total) const {
+        if (count == 0) {
+            std::printf("  %-28s ok (%zu values)\n", label, total);
+            return;
+        }
+        std::fprintf(stderr,
+                     "  %-28s %d/%zu differ; first at %zu: got %g want %g\n",
+                     label, count, total, first, got, want);
+    }
+};
+
+}  // namespace
+
+int main() {
+    std::printf("qwen3_5 conv state layout\n");
+    sycl::queue& queue = GpuEngine::get(0).queue;
+    const int tokens = 5;
+
+    std::vector<bf16> host_input = sample_vector((size_t)tokens * kChannels, 0x51ce);
+    GpuBuffer<bf16> input(host_input.size(), queue);
+    input.upload(host_input.data(), host_input.size());
+
+    // 1. The chunked writer must leave the state time-major. Written out as an
+    //    explicit index rather than compared against another kernel, so the
+    //    contract is readable from the test alone.
+    {
+        GpuBuffer<bf16> state((size_t)kHistory * kChannels, queue);
+        state.zero();
+        qwen35_update_conv_state(queue, input.data(), state.data(), tokens,
+                                 kChannels, kKernel, /*had_state=*/false);
+        queue.wait();
+        std::vector<bf16> host_state = download(state);
+        Mismatch m;
+        for (int slot = 0; slot < kHistory; ++slot) {
+            int source = tokens - kHistory + slot;
+            for (int channel = 0; channel < kChannels; ++channel) {
+                size_t at = (size_t)slot * kChannels + channel;
+                m.observe(at, host_state[at],
+                          host_input[(size_t)source * kChannels + channel]);
+            }
+        }
+        m.report("writer is time-major", host_state.size());
+        CHECK(m.count == 0);
+    }
+
+    // 2. Both writers must produce identical bytes from identical inputs. This
+    //    is the check the layout split failed: each writer was self-consistent,
+    //    so only comparing them against each other exposes the disagreement.
+    {
+        GpuBuffer<bf16> chunked((size_t)kHistory * kChannels, queue);
+        GpuBuffer<bf16> fused((size_t)kHistory * kChannels, queue);
+        std::vector<bf16> seed = sample_vector((size_t)kHistory * kChannels, 0xc0de);
+        chunked.upload(seed.data(), seed.size());
+        fused.upload(seed.data(), seed.size());
+
+        // One token appended to an existing history, the prefill-to-decode step.
+        const bf16* last = input.data() + (size_t)(tokens - 1) * kChannels;
+        qwen35_update_conv_state(queue, last, chunked.data(), /*seq=*/1,
+                                 kChannels, kKernel, /*had_state=*/true);
+        qwen35_update_conv_state_time_major(queue, last, kChannels, fused.data(),
+                                            kChannels);
+        queue.wait();
+        std::vector<bf16> host_chunked = download(chunked);
+        std::vector<bf16> host_fused = download(fused);
+        Mismatch m;
+        for (size_t i = 0; i < host_chunked.size(); ++i)
+            m.observe(i, host_chunked[i], host_fused[i]);
+        m.report("writers agree", host_chunked.size());
+        CHECK(m.count == 0);
+    }
+
+    // 3. Continuity across the boundary: convolving a whole sequence at once
+    //    must equal convolving a prefix, carrying the state, and convolving the
+    //    remainder. This is what a caller actually depends on, and it is the
+    //    regression guard for the reader half of the fix.
+    {
+        std::vector<bf16> host_weight =
+            sample_vector((size_t)kChannels * kKernel, 0x7a95);
+        GpuBuffer<bf16> weight(host_weight.size(), queue);
+        weight.upload(host_weight.data(), host_weight.size());
+
+        GpuBuffer<bf16> whole((size_t)tokens * kChannels, queue);
+        GpuBuffer<bf16> empty(kHistory * kChannels, queue);
+        empty.zero();
+        qwen35_conv_causal(queue, input.data(), weight.data(), empty.data(),
+                           whole.data(), tokens, kChannels, kKernel,
+                           /*has_state=*/false);
+
+        const int split = tokens - 1;
+        GpuBuffer<bf16> state((size_t)kHistory * kChannels, queue);
+        GpuBuffer<bf16> prefix((size_t)split * kChannels, queue);
+        GpuBuffer<bf16> tail(kChannels, queue);
+        state.zero();
+        qwen35_conv_causal(queue, input.data(), weight.data(), state.data(),
+                           prefix.data(), split, kChannels, kKernel,
+                           /*has_state=*/false);
+        qwen35_update_conv_state(queue, input.data(), state.data(), split,
+                                 kChannels, kKernel, /*had_state=*/false);
+        qwen35_conv_causal(queue, input.data() + (size_t)split * kChannels,
+                           weight.data(), state.data(), tail.data(), 1, kChannels,
+                           kKernel, /*has_state=*/true);
+        queue.wait();
+
+        std::vector<bf16> host_whole = download(whole);
+        std::vector<bf16> host_tail = download(tail);
+        Mismatch m;
+        for (int channel = 0; channel < kChannels; ++channel)
+            m.observe(channel, host_tail[channel],
+                      host_whole[(size_t)split * kChannels + channel]);
+        m.report("prefill/decode continuity", kChannels);
+        CHECK(m.count == 0);
+    }
+
+    RETURN_TESTS();
+}


### PR DESCRIPTION
Two defects in the Qwen3.5 DeltaNet decode path, both silent. A GPU regression test lands with them.

## 1. The conv state had two incompatible layouts

`cache.conv_state` is one buffer written and read by two paths:

- chunked (`qwen35_conv_causal` + `qwen35_update_conv_state`) — prefill, and any batch wider than the fused decode window
- fused ESIMD decode (`qwen35_delta_decode_fused_esimd` + `qwen35_update_conv_state_time_major`) — single tokens

They indexed it differently. Chunked used channel-major `state[channel*history + slot]`; fused uses time-major `state[slot*channels + channel]`. Nothing converts between them, and with `conv_dim` 10240 against `history` 3 those are unrelated addresses.

Prefill always runs the chunked path and decode always ran the fused one, so **every prompt handed its first decode tokens a conv history read at the wrong offsets**, recovering only once `history` real tokens had shifted through. Output stays fluent, which is why it went unnoticed.

`benchmarks/delta_decode_fusion_bench.cpp` could not have caught it — it gives each path its own state buffer and so never crosses the boundary.

Both are time-major now.

## 2. The fused decode core was gated on `seq == 1`

Any wider batch fell through to the chunked path, and the two are not numerically equivalent. Batch size therefore decided the answer: a two-token forward and two one-token forwards over the same tokens produced different logits. That is invisible to today's callers (decode is always `seq == 1`) but breaks anything that verifies a batch against sequential decoding.

The guard is now `seq <= ARCAINE_QWEN35_FUSED_DECODE_MAX_SEQ` (default 8), running the core once per token. Only the recurrent core loops — the projection above it is already batched over the window — so weight traffic is unchanged.

## Test

`tests/modeling/qwen3_5/test_conv_state_layout.cpp`, new ctest target. Needs a GPU, needs no model dir, runs in 0.2 s. Pins three properties:

1. the chunked writer leaves the state time-major
2. the two writers produce identical bytes from identical inputs
3. convolving a sequence whole equals convolving it in two parts across a carried state

## Validation

Qwen3.6-27B-NVFP4, one BMG G31.

Test against the unfixed kernels:

```
writer is time-major   190/192 values differ   FAIL
writers agree          191/192 differ          FAIL
prefill/decode continuity                      passes
```

Check 3 passing while broken is the point: each writer was internally self-consistent, so only a cross-writer comparison exposes the split. After the fix all three pass.

Throughput, `arcaine_mbench -p 512 -n 32 -d 0,2048 -r 3 -w 1`:

```
pp 512   667 t/s
tg 32    12.78 t/s @ depth 0, 9.51 t/s @ 2048
```

Identical with `ARCAINE_QWEN35_FUSED_DECODE_MAX_SEQ=1`, which restores the original condition exactly — decode and prefill never use a batch in 2..8, so the guard change is inert for them.

`ctest` 6/6. `arcaine_smoke_qwen35` → `SMOKE_OK`.