### PR TITLE
qwen3_5: two DeltaNet state-layout fixes (prefill b|a, and ESIMD_DELTA=0)

### DIFF
--- a/src/modeling/qwen3_5/model.cpp
+++ b/src/modeling/qwen3_5/model.cpp
@@ -45,7 +45,7 @@ Qwen35Model::Qwen35Model(const std::string& model_dir, int max_seq_len)
     }
     std::printf("[qwen35] %d GPU(s), layer split=%d, NVFP4 DPAS=%s, "
                 "XMX attention=%s, ESIMD DeltaNet=%s, "
-                "fused Delta decode=%s, fused BA=%s, "
+                "fused Delta decode=%s, fused BA (decode only)=%s, "
                 "persistent IO=%s\n",
                 GpuEngine::count(), split_layer_,
                 qwen35_nvfp4_dpas_enabled() ? "on" : "off",

--- a/src/modeling/qwen3_5/operators.hpp
+++ b/src/modeling/qwen3_5/operators.hpp
@@ -99,6 +99,10 @@ inline void matmul_proj(const bf16* A, int M, int K, const Qwen35Proj& W,
         matmul_int4(A, M, K, std::get<Int4Linear>(W), C, context);
 }
 
+// Gates the fused [b|a] projection on the M=1 decode path only. The
+// multi-token prefill path cannot use it - the fused output interleaves b and
+// a per token, which is not the layout its consumers read - and no longer
+// consults this flag.
 inline bool qwen35_fused_ba_projection_enabled() {
     static bool enabled = [] {
         const char* value =
@@ -292,15 +296,31 @@ inline void qwen35_linear_attention_forward(
                     workspace.tmp0.data(), context);
     bf16* beta = workspace.tmp1.data();
     bf16* g = workspace.tmp1.data() + head_values;
-    if (qwen35_fused_ba_projection_enabled())
-        matmul_bf16(hidden, seq, c.hidden_size, weights.in_proj_ba.data(),
-                    2 * heads, beta, context);
-    else {
-        matmul_bf16(hidden, seq, c.hidden_size, weights.in_proj_b.data(), heads,
-                    beta, context);
-        matmul_bf16(hidden, seq, c.hidden_size, weights.in_proj_a.data(), heads,
-                    g, context);
-    }
+    // Two matmuls, deliberately, even though a fused [b|a] weight exists.
+    //
+    // matmul_bf16 writes C(M,N) row-major, and in_proj_ba stacks b's rows then
+    // a's, so C(seq, 2*heads) comes back with each token's b and a adjacent:
+    // token t occupies [t*2*heads, (t+1)*2*heads). The two consumers below read
+    // separate contiguous blocks instead - beta at tmp1 and g at
+    // tmp1 + seq*heads, both indexed [token * heads + head] - which describes
+    // the same bytes only when seq == 1.
+    //
+    // Using the fused matmul here therefore fed the DeltaNet recurrence some
+    // other token's gate values for every token after the first, on the
+    // default configuration, for any prompt longer than the fused-decode
+    // guard's 8 tokens. Measured against a corrected engine over 1000 records:
+    // top-1 agreement 0.87 and perplexity 191.99 against 186.16.
+    //
+    // It survived because the decode path above builds ba per token at M=1,
+    // where the two layouts coincide, and because scrambled gates perturb the
+    // output rather than obviously breaking it.
+    //
+    // These are hidden_size x heads GEMMs, launch-bound at any sequence
+    // length: pp512 measures 664.45 -> 664.20 t/s, inside run-to-run noise.
+    matmul_bf16(hidden, seq, c.hidden_size, weights.in_proj_b.data(), heads,
+                beta, context);
+    matmul_bf16(hidden, seq, c.hidden_size, weights.in_proj_a.data(), heads,
+                g, context);
     sigmoid_inplace(queue, beta, head_values);
     qwen35_compute_g(queue, g, weights.A_log.data(), weights.dt_bias.data(),
                      g, seq, heads);

--- a/src/modeling/qwen3_5/operators.hpp
+++ b/src/modeling/qwen3_5/operators.hpp
@@ -225,8 +225,38 @@ inline void qwen35_linear_attention_forward(
     // Only the recurrent core loops. The projection above is already batched
     // over the whole window, so this re-reads the recurrent state and the small
     // conv/gate tensors, not the weights.
+    // qwen35_esimd_delta_enabled() belongs here even though this arm never
+    // calls qwen35_recurrent_delta_esimd.
+    //
+    // Both arms advance the same cache.recurrent_state, and the three
+    // recurrent implementations do not agree on its layout:
+    //
+    //   qwen35_recurrent_delta        state[head*K*V + k*V + v]  [head][key][value]
+    //   qwen35_recurrent_delta_esimd  state[head*V*K + v*K + k]  [head][value][key]
+    //   qwen35_delta_decode_fused_esimd (below)                  [head][value][key]
+    //
+    // K and V are both 128 here, so a mismatch is exactly size-compatible:
+    // nothing faults, the state is silently transposed between the prefill
+    // that wrote it and the decode that reads it.
+    //
+    // Without this term, ARCAINE_QWEN35_ESIMD_DELTA=0 selects the scalar
+    // kernel for prefill while leaving the fused ESIMD core on for decode, and
+    // the two corrupt each other across every generation. Measured over 400
+    // teacher-forced records, that arm agreed with the default configuration on
+    // 33.75% of tokens, against 92% or better for every other kernel flag.
+    // An fp64 host reference puts both recurrent kernels within 0.67 bf16 ULP
+    // of the true recurrence, so neither was ever at fault - only the pairing.
+    // With this term the same arm reports 92.75%, in line with the rest.
+    //
+    // kernels.hpp already noted that a cache must not switch layouts
+    // mid-stream; nothing enforced it. The flag now switches the whole
+    // DeltaNet path coherently, which is what a baseline A/B switch should do.
+    // The deeper fix is to give the scalar kernel the same [head][value][key]
+    // layout so no combination can mix them; this makes the unsafe one
+    // unreachable meanwhile.
     if (seq >= 1 && seq <= qwen35_fused_decode_max_seq() &&
-        weights.fused_projections && qwen35_fused_esimd_delta_decode_enabled()) {
+        weights.fused_projections && qwen35_fused_esimd_delta_decode_enabled() &&
+        qwen35_esimd_delta_enabled()) {
         for (int token = 0; token < seq; ++token) {
             const bf16* token_hidden = hidden + (size_t)token * c.hidden_size;
             const bf16* projected =


### PR DESCRIPTION
Two bugs where a buffer is written with one layout and read with another. In both cases the sizes coincide, so nothing faults and the corruption shows up only in the numbers.

Neither was introduced by #10 — both predate it, and widening that guard from `seq == 1` to `seq <= 8` incidentally narrowed the reach of each.

| | affects | measured |
|---|---|---|
| **1. fused `b\|a` on prefill** | **default config, every prompt over 8 tokens** | 13% of generated tokens change |
| **2. `ESIMD_DELTA=0` state layout** | that flag only; never a default run | that arm's A/B baseline was corrupt |

---

# 1. Fused `b|a` projection on the prefill path

### What's wrong

`matmul_bf16` writes `C(M,N)` row-major (`tag::ab`), and `in_proj_ba` stacks b's rows then a's. So `C(seq, 2*heads)` comes back with each token's `b` and `a` adjacent:

```
token t occupies [t*2*heads, (t+1)*2*heads)  =  [b0..b_{h-1}, a0..a_{h-1}]
```

The consumers read two separate contiguous blocks instead:

```cpp
bf16* beta = workspace.tmp1.data();
bf16* g    = workspace.tmp1.data() + head_values;   // head_values = seq*heads
// ...both later indexed [token * heads + head]
```

Those are the same bytes **only when `seq == 1`**. Above that, `beta[t*heads + j]` reads element `t*heads + j` of a `2*heads`-strided matrix — some other token's `b` or `a`. The DeltaNet recurrence gets wrong gate values for every prefill token after the first.

### Why it wasn't caught

The decode path builds `ba` per token at M=1, where the layouts coincide. The fused-decode guard sends `seq <= 8` through that same per-token loop. And wrong gates perturb the output rather than breaking it, so generated text stayed coherent.

### Impact

Old path vs a corrected engine's golden, 200 teacher-forced records:

| | |
|---|---:|
| top-1 agreement | 0.8700 (174/200) |
| perplexity | 186.16 → 191.99 |
| `max \|dlogit\|` | 19.47 |

### Fix and its cost

Prefill issues the two separate matmuls. These are `hidden_size × heads` GEMMs, launch-bound at any sequence length:

```
pp512   664.45 -> 664.20 t/s      (run-to-run sd 0.79 and 0.21)
tg32     12.64 -> 12.64 t/s
```

Free, within noise.

---

# 2. `ESIMD_DELTA=0` splits the recurrent state across two layouts

### What's wrong

The three DeltaNet implementations disagree on the state layout:

```
qwen35_recurrent_delta           state[head*K*V + k*V + v]   [head][key][value]
qwen35_recurrent_delta_esimd     state[head*V*K + v*K + k]   [head][value][key]
qwen35_delta_decode_fused_esimd                              [head][value][key]
```

Both arms of the fused-decode guard advance the same `cache.recurrent_state`, but the per-token arm was gated on `qwen35_fused_esimd_delta_decode_enabled()` alone. So `ARCAINE_QWEN35_ESIMD_DELTA=0` picks the scalar kernel for prefill and leaves the fused ESIMD core on for decode:

```
prefill  writes [head][key][value]
decode   reads  [head][value][key]     same buffer, silently transposed
```

K and V are both 128, so it is exactly size-compatible. `kernels.hpp` already noted a cache must not switch layouts mid-stream; nothing enforced it.

### Impact

Over 400 teacher-forced records, that arm agreed with the default configuration on **33.75%** of tokens, against 92% or better for every other kernel flag.

An fp64 host reference puts both recurrent kernels within 0.67 bf16 ULP of the true recurrence — neither kernel is wrong, only the pairing.

### Fix

`qwen35_esimd_delta_enabled()` joins the guard, so the flag switches the whole DeltaNet path coherently. That arm now reports **92.75%**, in line with every other flag. The default had ESIMD on both sides and never mixed, so it is bit-exact unchanged.

A cleaner fix later would be to give the scalar kernel the `[head][value][key]` layout so no combination *can* mix them.

---

# What this gains

1. **Correct output on every prompt over 8 tokens.** Bug 1 is live in the default configuration today.
2. **The engine becomes deterministic.** Bug 1 was also the cause of same-prompt, same-seed runs producing different logits about two times in three. After the fix: bit-exact 10/10 across processes, 4/4 within a process, over 200 records. This unblocks quantization and kernel A/B work, where any delta smaller than the noise band was previously unmeasurable.
3. **Kernel A/B comparisons get a trustworthy baseline.** Bug 2 made `ESIMD_DELTA=0` — the documented scalar baseline — produce corrupt output, so anything measured against it was wrong.

# Testing

`ctest` 6/6 on `arch-refactor` (the tests my oneDNN build can compile — see build note). Default configuration bit-exact after both commits: `max |dlogit| 0`, top-1 400/400 against a pre-change golden.

Bug 1 was found with an in-process repeat probe — replay the same trajectory N times inside one process and compare each pass to the first, which separates "memory started out different" from "the ordering is not stable". I can send that harness and the two fp64 oracles (recurrence, attention) as a follow-up PR if useful; they are benchmark-only and none of it is on the inference path.

# Build note (my environment, not this branch)

`arcaine_kbench` and `arcaine_server` need oneDNN built with
`DNNL_EXPERIMENTAL_GROUPED_MEMORY` for `qwen3_5_moe`'s grouped matmul. Mine was not,
so I could only build and test the `qwen3_5` targets. Nothing to do with this PR —
noting it in case it is worth a line in the build docs.
