### PR TITLE
runtime: split large device transfers so model loads do not hang

### DIFF
--- a/src/runtime/gpu/buffer.hpp
+++ b/src/runtime/gpu/buffer.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstring>
@@ -76,20 +77,75 @@ public:
     bool   empty() const { return ptr_ == nullptr; }
 
     void upload(const T* host, size_t n) {
-        q_->memcpy(ptr_, host, n * sizeof(T)).wait();
+        copy_chunked(ptr_, host, n * sizeof(T));
     }
 
     void download(T* host, size_t n) const {
-        q_->memcpy(host, ptr_, n * sizeof(T)).wait();
+        copy_chunked(host, ptr_, n * sizeof(T));
     }
 
     void zero() {
-        q_->memset(ptr_, 0, count_ * sizeof(T)).wait();
+        // memset takes the same path as memcpy in the driver, so it gets the
+        // same treatment; a large KV cache is well over the limit.
+        size_t remaining = count_ * sizeof(T);
+        char* dst = reinterpret_cast<char*>(ptr_);
+        sycl::event last;
+        while (remaining) {
+            size_t step = std::min(remaining, kMaxTransferBytes);
+            last = q_->memset(dst, 0, step);
+            dst += step;
+            remaining -= step;
+        }
+        if (count_) last.wait();
     }
 
     sycl::queue& queue() const { return *q_; }
 
 private:
+    // Large single transfers can stall indefinitely on some kernel/driver
+    // pairings: the copy is enqueued, its event never signals, and the runtime
+    // spins in sched_yield() forever. It is a hang, not a slow path - nothing
+    // times out and no error is reported.
+    //
+    // Observed loading Qwen3.6-27B on an Arc Pro B70 under kernel 7.0: the load
+    // stops with device memory frozen at ~2.5 GB, which is the embedding
+    // table's size, and the backtrace sits in urEventWait under
+    // GpuBuffer::upload. The same binary and card under kernel 6.17 never
+    // stalls, and swapping the GPU userspace across 26.18 / 26.22 / 26.27
+    // changes nothing, so it is below the userspace.
+    //
+    // **The mechanism is not established.** A standalone SYCL reproducer with
+    // no oneDNN and no model stalls only intermittently: a 2 GiB copy hung
+    // once, 1 GiB on an in-order queue hung once, and a size sweep from 256 MiB
+    // to 1 GiB then passed cleanly on the same machine minutes later. So the
+    // trigger is not simply "copies above size N", and this constant is an
+    // empirical mitigation, not a documented boundary. What is consistent is
+    // that this engine reproduces it reliably where the probes do not, and this
+    // engine differs by doing ~1968 allocate-then-copy pairs during load.
+    // llama.cpp on the same host is unaffected and also splits its transfers.
+    //
+    // 256 MiB was the largest size that never stalled in any probe run. If a
+    // load hangs again, lower it and re-test rather than assuming this value is
+    // principled. Splitting costs nothing measurable - the pieces sustain the
+    // same GB/s - and the queue is in-order, so ordering holds and only the
+    // final event needs waiting on.
+    static constexpr size_t kMaxTransferBytes = 256ull * 1024ull * 1024ull;
+
+    void copy_chunked(void* dst, const void* src, size_t bytes) const {
+        char* d = static_cast<char*>(dst);
+        const char* s = static_cast<const char*>(src);
+        sycl::event last;
+        size_t remaining = bytes;
+        while (remaining) {
+            size_t step = std::min(remaining, kMaxTransferBytes);
+            last = q_->memcpy(d, s, step);
+            d += step;
+            s += step;
+            remaining -= step;
+        }
+        if (bytes) last.wait();
+    }
+
     T*           ptr_   = nullptr;
     size_t       count_ = 0;
     sycl::queue* q_     = nullptr;


### PR DESCRIPTION
## What this fixes

Loading Qwen3.6-27B on an Arc Pro B70 under **kernel 7.0** hangs. Device memory freezes at ~2.5 GB — exactly the embedding table's size — and the process spins forever in `urEventWait` beneath `GpuBuffer::upload`. The copy is enqueued and its event never signals. No error, no timeout, no progress; the model simply never loads.

The card is fine — llama.cpp runs on the same host, and it already splits its transfers.

## The change

`GpuBuffer::upload/download/zero` issue at most 256 MiB per operation instead of one whole-buffer transfer. The queue is in-order, so ordering is preserved and only the final event is waited on.

## Measured

| | before | after |
|---|---|---|
| affected host (kernel 7.0), 3 consecutive loads | never completed | pp512 647.8 / 661.7 / 657.7, tg 13.53 |
| unaffected host (kernel 6.17) | pp512 668.9, tg 12.64 | pp512 669.2, tg 12.65 |

No measurable cost — the pieces sustain the same GB/s.

## Caveat

This is a mitigation, not a root fix, and the mechanism is **not** established. A standalone SYCL reproducer (no oneDNN, no model) stalls only intermittently: a 2 GiB copy hung once, 1 GiB on an in-order queue hung once, then a 256 MiB–1 GiB sweep passed cleanly on the same machine minutes later. Copy size, cumulative volume and in-order queueing each looked like the trigger and each failed to reproduce.

256 MiB is simply the largest size that never stalled in any run. The comment in the code says so rather than implying a documented limit. What is consistent: this engine reproduces the stall reliably where the probes do not, and it differs by doing ~1968 allocate-then-copy pairs per load.

Swapping GPU userspace across 26.18 / 26.22 / 26.27 changes nothing, so the trigger is below the userspace. Worth reporting the reproducer to `intel/compute-runtime` separately — happy to file that if useful.
